### PR TITLE
Generalization of the `.git/MERGE_MSG' path

### DIFF
--- a/ciq-cherry-pick.py
+++ b/ciq-cherry-pick.py
@@ -1,11 +1,12 @@
 import argparse
 import os
 import subprocess
+import git
 from ciq_helpers import CIQ_cherry_pick_commit_standardization
 from ciq_helpers import CIQ_original_commit_author_to_tag_string
 # from ciq_helpers import *
 
-MERGE_MSG = '.git/MERGE_MSG'
+MERGE_MSG = git.Repo(os.getcwd()).git_dir + '/MERGE_MSG'
 
 if __name__ == '__main__':
     print("CIQ custom cherry picker")


### PR DESCRIPTION
Generalization of the `.git/MERGE_MSG` path

In general the `MERGE_MSG` file doesn't need to be located under the local `.git` directory. In these cases the script `ciq-cherry-pick.py` will fail.

An example would be a git repository created with `git-worktree`. Assume the current directory contains a regular git repository `some-project` with a branch `branch-x` and some commit with a hash ‹some-commit›. Without this change the last command would fail while it shouldn't

    cd some-project
    git worktree add ../some-project-branch-x  branch-x
    cd ../some-project-branch-x
    python3 ‹kernel-src-tree-tools-dir›/ciq-cherry-pick.py --sha ‹some-commit›

In case of the `some-project-branch-x` repository the `MERGE_MSG` file is under `some-project/.git/worktrees/some-project-branch-x/MERGE_MSG`.

While the `git worktree` may seem an exotic feature of git, it lends itself perfectly to making the same logical change across multiple branches, like the task of backporting bug fixes to different Rocky versions - a motivation for the `ciq-cherry-pick.py` program. It may therefore be expected to be used more often than usual in conjunction with this tool.

