### PR TITLE
[CCP] Fix display of help for ciq-cherry-pick

### DIFF
--- a/ciq-cherry-pick.py
+++ b/ciq-cherry-pick.py
@@ -10,14 +10,14 @@ MERGE_MSG = git.Repo(os.getcwd()).git_dir + '/MERGE_MSG'
 
 if __name__ == '__main__':
     print("CIQ custom cherry picker")
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--sha', help='Taget SHA1 to cherry-pick')
-    parser.add_argument('--ticket', help='Ticket associtated to cherry-pick work')
+    parser.add_argument('--ticket', help='Ticket associated to cherry-pick work')
     parser.add_argument('--ciq-tag', help="Tags for commit message <feature><-optional modifier> <identifier>.\n"
                         "example: cve CVE-2022-45884 - A patch for a CVE Fix.\n"
                         "         cve-bf CVE-1974-0001 - A bug fix for a CVE currently being patched\n"
-                        "         cve-pre CVE-1974-0001 - A pre-condition or depnedency needed for the CVE\n"
-                        "Multiple tags are seperated with a comma. ex: cve CVE-1974-0001, cve CVE-1974-0002\n")
+                        "         cve-pre CVE-1974-0001 - A pre-condition or dependency needed for the CVE\n"
+                        "Multiple tags are separated with a comma. ex: cve CVE-1974-0001, cve CVE-1974-0002\n")
     args = parser.parse_args()
 
     tags = []


### PR DESCRIPTION
Found this while writing the wiki on `kernel-src-tree` 

## Original
```
[jmaple@devbox kernel-src-tree-tools]$ python3 ciq-cherry-pick.py --help
CIQ custom cherry picker
usage: ciq-cherry-pick.py [-h] [--sha SHA] [--ticket TICKET] [--ciq-tag CIQ_TAG]

optional arguments:
  -h, --help         show this help message and exit
  --sha SHA          Taget SHA1 to cherry-pick
  --ticket TICKET    Ticket associtated to cherry-pick work
  --ciq-tag CIQ_TAG  Tags for commit message <feature><-optional modifier> <identifier>. example: cve CVE-2022-45884 - A patch for a CVE Fix. cve-bf CVE-1974-0001 - A bug fix for a CVE currently being patched cve-pre CVE-1974-0001 - A pre-condition or depnedency needed for the CVE Multiple tags are seperated with a comma. ex: cve CVE-1974-0001, cve
                     CVE-1974-0002
```

## New
```
[jmaple@devbox kernel-src-tree-tools]$ python3 ciq-cherry-pick.py --help
CIQ custom cherry picker
usage: ciq-cherry-pick.py [-h] [--sha SHA] [--ticket TICKET] [--ciq-tag CIQ_TAG]

optional arguments:
  -h, --help         show this help message and exit
  --sha SHA          Taget SHA1 to cherry-pick
  --ticket TICKET    Ticket associated to cherry-pick work
  --ciq-tag CIQ_TAG  Tags for commit message <feature><-optional modifier> <identifier>.
                     example: cve CVE-2022-45884 - A patch for a CVE Fix.
                              cve-bf CVE-1974-0001 - A bug fix for a CVE currently being patched
                              cve-pre CVE-1974-0001 - A pre-condition or dependency needed for the CVE
                     Multiple tags are separated with a comma. ex: cve CVE-1974-0001, cve CVE-1974-0002
```