### PR TITLE
specify short commit hash in LOCALVERSION

### DIFF
--- a/kernel_build.sh
+++ b/kernel_build.sh
@@ -47,8 +47,8 @@ else
 fi
 
 echo "Setting Local Version for build"
-sed -i_bak "s/CONFIG_LOCALVERSION=\"\"/CONFIG_LOCALVERSION=\"-${BRANCH}\"/g" .config
-grep "CONFIG_LOCALVERSION=" .config    
+sed -i_bak "s/CONFIG_LOCALVERSION=\"\"/CONFIG_LOCALVERSION=\"-${BRANCH}-$(git rev-parse --short HEAD)\"/g" .config
+grep "CONFIG_LOCALVERSION=" .config
 
 echo "Making olddefconfig"
 make olddefconfig


### PR DESCRIPTION
Currently, there is no way to differentiate between kernels built against different commits in the same branch. Add a short commit hash to the LOCALVERSION to resolve the confusion.

Script's output after the modification:
```
$ head -n 30 ~/kernel_build.log
/home/ciq/kernel-src-tree
no .config file found, moving on
[TIMER]{MRPROPER}: 0s
x86_64 architecture detected, copying config
'configs/kernel-x86_64-rhel.config' -> '.config'
Setting Local Version for build
CONFIG_LOCALVERSION="-ciqlts9_4-201ea9b33"
Making olddefconfig
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  HOSTCC  scripts/kconfig/confdata.o
  HOSTCC  scripts/kconfig/expr.o
  LEX     scripts/kconfig/lexer.lex.c
  YACC    scripts/kconfig/parser.tab.[ch]
  HOSTCC  scripts/kconfig/lexer.lex.o
  HOSTCC  scripts/kconfig/menu.o
  HOSTCC  scripts/kconfig/parser.tab.o
  HOSTCC  scripts/kconfig/preprocess.o
  HOSTCC  scripts/kconfig/symbol.o
  HOSTCC  scripts/kconfig/util.o
  HOSTLD  scripts/kconfig/conf
#
# configuration written to .config
#
Starting Build
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_32.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_64.h
  SYSHDR  arch/x86/include/generated/uapi/asm/unistd_x32.h
  SYSTBL  arch/x86/include/generated/asm/syscalls_32.h
  SYSHDR  arch/x86/include/generated/asm/unistd_32_ia32.h

$ tail -n 10 ~/kernel_build.log
  SIGN    /lib/modules/5.14.0-ciqlts9_4-201ea9b33+/kernel/virt/lib/irqbypass.ko
  DEPMOD  /lib/modules/5.14.0-ciqlts9_4-201ea9b33+
[TIMER]{MODULES}: 33s
Making Install
sh ./arch/x86/boot/install.sh 5.14.0-ciqlts9_4-201ea9b33+ \
        arch/x86/boot/bzImage System.map "/boot"
[TIMER]{INSTALL}: 11s
Checking kABI
/run/media/kernel/kernel-src-tree-tools/kernel_build.sh: line 91: ../kernel-dist-git/SOURCES/check-kabi: No such file or directory
Error: kABI check failed
```

[kernel_build.log](https://github.com/user-attachments/files/19190701/kernel_build.log)