### PR TITLE
Introduction of Rolling Release forward port Script

### DIFF
--- a/kernel_build.sh
+++ b/kernel_build.sh
@@ -65,7 +65,7 @@ echo "[TIMER]{BUILD}: $(( $END_BUILD - $START_BUILD ))s"
 
 echo "Making Modules"
 START_MODULES=$(date +%s)
-sudo INSTALL_MOD_STRIP=1 make modules_install
+sudo INSTALL_MOD_STRIP=1 make -j$(nproc) modules_install
 if [ $? -ne 0 ]; then
     echo "Error: Modules install failed"
     echo "[TIMER]{MODULES} $(( $(date +%s) - $START_MODULES ))s"

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -1,0 +1,129 @@
+import argparse
+import json
+import os
+import subprocess
+import re
+import git
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Rolling release update')
+    parser.add_argument('--repo', help='Repository path', required=True)
+    parser.add_argument('--new-base-branch', help='Branch name', required=True)
+    parser.add_argument('--old-rolling-branch', help='Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10', required=True)
+    args = parser.parse_args()
+
+
+    rolling_product = args.old_rolling_branch.split('/')[0]
+    print('[rolling release update] Rolling Product: ', rolling_product)
+
+    repo = git.Repo(args.repo)
+    print('[rolling release update] Checking out old Rolling Branch: ', args.old_rolling_branch)
+    repo.git.checkout(args.old_rolling_branch)
+    print('[rolling release update] Finding the last resf_kernel tag the rolling release was based')
+    results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+                            cwd=args.repo)
+    if results.returncode != 0:
+        print(results.stderr)
+        exit(1)
+    latest_resf_sha = ''
+    for line in results.stdout.split(b'\n'):
+        if b'tag: resf_kernel' in line:
+            print(line)
+            latest_resf_sha = line.split(b' ')[0]
+            break
+    print('[rolling release update] Last RESF tag sha: ', latest_resf_sha)
+
+    print('[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD')
+    rolling_commit_map = {}
+    rollint_commit_map_rev = {}
+    rolling_commits = repo.git.log(f'{latest_resf_sha.decode()}..HEAD')
+    for line in rolling_commits.split('\n'):
+        if line.startswith('commit '):
+            ciq_commit = line.split('commit ')[1]
+            rolling_commit_map[ciq_commit] = ''
+        if line.startswith('    commit '):
+            upstream_commit = line.split('    commit ')[1]
+            rolling_commit_map[ciq_commit] = upstream_commit
+            rollint_commit_map_rev[upstream_commit] = ciq_commit
+
+    print('{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }')
+    print(json.dumps(rolling_commit_map, indent=2))
+
+    
+    print('[rolling release update] Checking out new base branch: ', args.new_base_branch)
+    repo.git.checkout(args.new_base_branch)
+
+    print('[rolling release update] Finding the new resf_kernel tag the rolling release is based')
+    results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+                            cwd=args.repo)
+    if results.returncode != 0:
+        print(results.stderr)
+        exit(1)
+    
+    print('[rolling release update] Finding the kernel version for the new rolling release')
+    new_rolling_branch_kernel = ''
+    for line in results.stdout.split(b'\n'):
+        if b'tag: resf_kernel' in line:
+            print(line)
+            r = re.match(b'.*(?P<vendor>.*)_kernel-(?P<kernel_ver>[0-9.-]*el[89]_[0-9]*)', line)
+            print(r)
+            if r:
+                new_rolling_branch_kernel = r.group('kernel_ver')
+            break
+    new_rolling_branch_kernel = f'{rolling_product}/{new_rolling_branch_kernel.decode()}'
+    print('[rolling release update} New Branch to create ', new_rolling_branch_kernel)
+    
+    print('[rolling release update] Check if branch Exists: ', new_rolling_branch_kernel)
+    results = subprocess.run(['git', 'show-ref', '--quiet', f'refs/heads/{new_rolling_branch_kernel}'],
+                            stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=args.repo)
+    if results.returncode == 0:
+        print(f'Branch {new_rolling_branch_kernel} already exists')
+        exit(1)
+    else:
+        print(f'Branch {new_rolling_branch_kernel} does not exists creating')
+
+    results = subprocess.run(['git', 'checkout', '-b', new_rolling_branch_kernel], stderr=subprocess.PIPE,
+                            stdout=subprocess.PIPE, cwd=args.repo)
+    if results.returncode != 0:
+        print(results.stderr)
+        exit(1)
+    
+    print('[rolling release update] Crating Map of all new commits from last rolling release fork')
+    new_base_commit_map = {}
+    new_base_commit_map_rev = {}
+    new_base_commits = repo.git.log(f'{latest_resf_sha.decode()}..HEAD')
+    for line in new_base_commits.split('\n'):
+        if line.startswith('commit '):
+            ciq_commit = line.split('commit ')[1]
+            new_base_commit_map[ciq_commit] = ''
+        if line.startswith('    commit '):
+            upstream_commit = line.split('    commit ')[1]
+            new_base_commit_map[ciq_commit] = upstream_commit
+            new_base_commit_map_rev[upstream_commit] = ciq_commit
+
+    print('{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }')
+    print(json.dumps(new_base_commit_map, indent=2))
+
+    print('[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch')
+    commits_to_remove = {}
+    for ciq_commit, upstream_commit in rolling_commit_map.items():
+        if upstream_commit in new_base_commit_map_rev:
+            print(f"Commit {ciq_commit} already present in new base branch")
+            print(repo.git.show(ciq_commit))
+            commits_to_remove[ciq_commit] = upstream_commit
+
+    print('[rolling release update] Removing commits from the new branch')
+    for ciq_commit, upstream_commit in commits_to_remove.items():
+        del rolling_commit_map[ciq_commit]
+        print("Removing commit: ", ciq_commit)
+        repo.git.show(ciq_commit)
+
+    print('[rolling release update] Applying the remaining commits to the new branch')
+    for ciq_commit, upstream_commit in reversed(rolling_commit_map.items()):
+        print('Applying commit ', repo.git.show('--pretty="%H %s"', '-s', ciq_commit))
+        result = subprocess.run(['git', 'cherry-pick', '-s', ciq_commit], stderr=subprocess.PIPE,
+                                stdout=subprocess.PIPE, cwd=args.repo)
+        if result.returncode != 0:
+            print(result.stderr.split(b'\n'))
+            exit(1)
+

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -5,6 +5,9 @@ import subprocess
 import re
 import git
 
+FIPS_PROTECTED_DIRECOTRIES=[b'arch/x86/crypto/', b'cypto/aysmmetric_keys/', b'crypto/', b'drivers/crypto/',
+                            b'drivers/char/random.c', b'include/cyrpto']
+
 def find_common_tag(old_tags, new_tags):
     for tag in old_tags:
         if tag in new_tags:
@@ -28,11 +31,60 @@ def get_branch_tag_sha_list(repo, branch):
             tags.append(line.split(b' ')[0])
     return tags
 
+def check_for_fips_protected_changes(repo, branch, common_tag):
+    print('[rolling release update] Checking for FIPS protected changes')
+    repo.git.checkout(branch)
+    print(f'[rolling release update] Getting SHAS {common_tag.decode()}..HEAD')
+    results = subprocess.run(['git', 'log', '--pretty=%H', f'{common_tag.decode()}..HEAD'], stderr=subprocess.PIPE,
+                             stdout=subprocess.PIPE, cwd=repo.working_dir)
+    if results.returncode != 0:
+        print(results.stderr)
+        exit(1)
+
+    num_commits = len(results.stdout.split(b'\n'))
+    print('[rolling release update] Number of commits to check: ', num_commits)
+    shas_to_check = []
+    commits_checked = 0
+
+    print('[rolling release update] Checkking modifications of shas')
+    for sha in results.stdout.split(b'\n'):
+        commits_checked += 1
+        if commits_checked % (num_commits//10) == 0:
+            print(f'[rolling release update] Checked {commits_checked} of {num_commits} commits')
+        if sha == b'':
+            continue
+        res = subprocess.run(['git', 'show', '--name-only', '--pretty=%H %s',  f'{sha.decode()}'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+                                cwd=repo.working_dir)
+        if res.returncode != 0:
+            print(res)
+            print(res.stderr)
+            exit(1)
+
+        sha_hash_and_subject = b''
+        for line in res.stdout.split(b'\n'):
+            if sha_hash_and_subject == b'':
+                sha_hash_and_subject = line
+                continue
+            if line == b'':
+                continue
+
+            for dir in FIPS_PROTECTED_DIRECOTRIES:
+                if line.startswith(dir):
+                    print(f'FIPS protected directory change found in commit {sha}')
+                    print(sha_hash_and_subject)
+                    shas_to_check.append(sha_hash_and_subject.split(b' ')[0])
+            sha_hash_and_subject = b''
+    print(f'[rolling release update] {len(shas_to_check)} of {num_commits} commits have FIPS protected changes')
+
+    return shas_to_check
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Rolling release update')
     parser.add_argument('--repo', help='Repository path', required=True)
     parser.add_argument('--new-base-branch', help='Branch name', required=True)
     parser.add_argument('--old-rolling-branch', help='Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10', required=True)
+    parser.add_argument('--fips-override', help='Override FIPS check abort', action='store_true')
     args = parser.parse_args()
 
     repo = git.Repo(args.repo)
@@ -49,6 +101,17 @@ if __name__ == '__main__':
     latest_resf_sha = find_common_tag(old_rolling_branch_tags, new_base_branch_tags)
     print('[rolling release update] Latest RESF tag sha: ', latest_resf_sha)
     print(repo.git.show('--pretty="%H %s"', '-s', latest_resf_sha.decode()))
+
+    if 'fips' in rolling_product:
+        print('[rolling release update] Checking for FIPS protected changes between the common tag and HEAD')
+        shas_to_check = check_for_fips_protected_changes(repo, args.new_base_branch, latest_resf_sha)
+        if shas_to_check and args.fips_override is False:
+            for sha in shas_to_check:
+                print(repo.git.show(sha.decode()))
+            print('[rolling release update] FIPS protected changes found between the common tag and HEAD')
+            print('[rolling release update] Please Contact the CIQ FIPS / Security team for further instructions')
+            print('[rolling release update] Exiting')
+            exit(1)
 
 
     print('[rolling release update] Checking out old rolling branch: ', args.old_rolling_branch)
@@ -68,8 +131,14 @@ if __name__ == '__main__':
 
     print('[rolling release update] Last RESF tag sha: ', latest_resf_sha)
 
+    print('[rolling release update] Total Commit in old branch: ', len(rolling_commit_map))
     print('{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }')
-    print(json.dumps(rolling_commit_map, indent=2))
+    if len(rolling_commit_map) > 10:
+        print('Printing first 5 and last 5 commits')
+        print(json.dumps({k: rolling_commit_map[k] for k in list(rolling_commit_map)[:5]}, indent=2))
+        print(json.dumps({k: rolling_commit_map[k] for k in list(rolling_commit_map)[-5:]}, indent=2))
+    else:
+        print(json.dumps(rolling_commit_map, indent=2))
 
     print('[rolling release update] Checking out new base branch: ', args.new_base_branch)
     repo.git.checkout(args.new_base_branch)
@@ -118,8 +187,14 @@ if __name__ == '__main__':
             new_base_commit_map[ciq_commit] = upstream_commit
             new_base_commit_map_rev[upstream_commit] = ciq_commit
 
+    print('[rolling release update] Total Commit in new branch: ', len(new_base_commit_map))
     print('{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }')
-    print(json.dumps(new_base_commit_map, indent=2))
+    if len(new_base_commit_map) > 10:
+        print('Printing first 5 and last 5 commits')
+        print(json.dumps({k: new_base_commit_map[k] for k in list(new_base_commit_map)[:5]}, indent=2))
+        print(json.dumps({k: new_base_commit_map[k] for k in list(new_base_commit_map)[-5:]}, indent=2))
+    else:
+        print(json.dumps(new_base_commit_map, indent=2))
 
     print('[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch')
     commits_to_remove = {}

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -89,7 +89,14 @@ if __name__ == '__main__':
     parser.add_argument('--fips-override', help='Override FIPS check abort', action='store_true')
     parser.add_argument('--verbose-git-show', help='When SHAs are detected for removal do the full git show <sha>',
                         action='store_true')
+    parser.add_argument('--demo', help='DEMO mode, will make a new set of branches with demo_ prepended',
+                        action='store_true')
     args = parser.parse_args()
+
+    if args.demo:
+        print('======================== DEMO MODE ENABLED ==========================')
+        print('[rolling release update] DEMO mode enabled YOU SHOULD NOT COMMIT THIS')
+        print('======================== DEMO MODE ENABLED ==========================')
 
     repo = git.Repo(args.repo)
 
@@ -160,7 +167,11 @@ if __name__ == '__main__':
             if r:
                 new_rolling_branch_kernel = r.group('kernel_ver')
             break
-    new_rolling_branch_kernel = f'{rolling_product}/{new_rolling_branch_kernel.decode()}'
+
+    if args.demo:
+        new_rolling_branch_kernel = f'demo_{rolling_product}/{new_rolling_branch_kernel.decode()}'
+    else:
+        new_rolling_branch_kernel = f'{rolling_product}/{new_rolling_branch_kernel.decode()}'
     print('[rolling release update} New Branch to create ', new_rolling_branch_kernel)
     
     print('[rolling release update] Check if branch Exists: ', new_rolling_branch_kernel)

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -5,8 +5,8 @@ import subprocess
 import re
 import git
 
-FIPS_PROTECTED_DIRECOTRIES=[b'arch/x86/crypto/', b'cypto/aysmmetric_keys/', b'crypto/', b'drivers/crypto/',
-                            b'drivers/char/random.c', b'include/cyrpto']
+FIPS_PROTECTED_DIRECTORIES=[b'arch/x86/crypto/', b'cypto/asymmetric_keys/', b'crypto/', b'drivers/crypto/',
+                            b'drivers/char/random.c', b'include/crypto']
 
 def find_common_tag(old_tags, new_tags):
     for tag in old_tags:
@@ -46,7 +46,7 @@ def check_for_fips_protected_changes(repo, branch, common_tag):
     shas_to_check = []
     commits_checked = 0
 
-    print('[rolling release update] Checkking modifications of shas')
+    print('[rolling release update] Checking modifications of shas')
     for sha in results.stdout.split(b'\n'):
         commits_checked += 1
         if commits_checked % (num_commits//10) == 0:
@@ -68,7 +68,7 @@ def check_for_fips_protected_changes(repo, branch, common_tag):
             if line == b'':
                 continue
 
-            for dir in FIPS_PROTECTED_DIRECOTRIES:
+            for dir in FIPS_PROTECTED_DIRECTORIES:
                 if line.startswith(dir):
                     print(f'FIPS protected directory change found in commit {sha}')
                     print(sha_hash_and_subject)
@@ -196,7 +196,7 @@ if __name__ == '__main__':
         exit(1)
 
     
-    print('[rolling release update] Crating Map of all new commits from last rolling release fork')
+    print('[rolling release update] Creating Map of all new commits from last rolling release fork')
     new_base_commit_map = {}
     new_base_commit_map_rev = {}
     new_base_commits = repo.git.log(f'{latest_resf_sha.decode()}..HEAD')

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -167,12 +167,19 @@ if __name__ == '__main__':
         exit(1)
     else:
         print(f'Branch {new_rolling_branch_kernel} does not exists creating')
+        results = subprocess.run(['git', 'checkout', '-b', new_rolling_branch_kernel], stderr=subprocess.PIPE,
+                                stdout=subprocess.PIPE, cwd=args.repo)
+    if results.returncode != 0:
+        print(results.stderr)
+        exit(1)
 
-    results = subprocess.run(['git', 'checkout', '-b', new_rolling_branch_kernel], stderr=subprocess.PIPE,
+    print('[rolling release update] Creating new branch for PR: ', f"{os.getlogin()}_{new_rolling_branch_kernel}")
+    results = subprocess.run(['git', 'checkout', '-b', f"{os.getlogin()}_{new_rolling_branch_kernel}"], stderr=subprocess.PIPE,
                             stdout=subprocess.PIPE, cwd=args.repo)
     if results.returncode != 0:
         print(results.stderr)
         exit(1)
+
     
     print('[rolling release update] Crating Map of all new commits from last rolling release fork')
     new_base_commit_map = {}

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -5,6 +5,29 @@ import subprocess
 import re
 import git
 
+def find_common_tag(old_tags, new_tags):
+    for tag in old_tags:
+        if tag in new_tags:
+            return tag
+    return None
+
+def get_branch_tag_sha_list(repo, branch):
+    print('[rolling release update] Checking out branch: ', branch)
+    repo.git.checkout(branch)
+    results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+                            cwd=repo.working_dir)
+    if results.returncode != 0:
+        print(results.stderr)
+        exit(1)
+
+    print('[rolling release update] Gathering all the RESF kernel Tags')
+    tags = []
+    for line in results.stdout.split(b'\n'):
+        if b'tag: resf_kernel' in line:
+            print(line)
+            tags.append(line.split(b' ')[0])
+    return tags
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Rolling release update')
     parser.add_argument('--repo', help='Repository path', required=True)
@@ -12,27 +35,24 @@ if __name__ == '__main__':
     parser.add_argument('--old-rolling-branch', help='Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10', required=True)
     args = parser.parse_args()
 
+    repo = git.Repo(args.repo)
 
     rolling_product = args.old_rolling_branch.split('/')[0]
     print('[rolling release update] Rolling Product: ', rolling_product)
 
-    repo = git.Repo(args.repo)
-    print('[rolling release update] Checking out old Rolling Branch: ', args.old_rolling_branch)
-    repo.git.checkout(args.old_rolling_branch)
-    print('[rolling release update] Finding the last resf_kernel tag the rolling release was based')
-    results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                            cwd=args.repo)
-    if results.returncode != 0:
-        print(results.stderr)
-        exit(1)
-    latest_resf_sha = ''
-    for line in results.stdout.split(b'\n'):
-        if b'tag: resf_kernel' in line:
-            print(line)
-            latest_resf_sha = line.split(b' ')[0]
-            break
-    print('[rolling release update] Last RESF tag sha: ', latest_resf_sha)
+    old_rolling_branch_tags = get_branch_tag_sha_list(repo, args.old_rolling_branch)
+    print('[rolling release update] Old Rolling Branch Tags: ', old_rolling_branch_tags)
 
+    new_base_branch_tags = get_branch_tag_sha_list(repo, args.new_base_branch)
+    print('[rolling release update] New Base Branch Tags: ', new_base_branch_tags)
+
+    latest_resf_sha = find_common_tag(old_rolling_branch_tags, new_base_branch_tags)
+    print('[rolling release update] Latest RESF tag sha: ', latest_resf_sha)
+    print(repo.git.show('--pretty="%H %s"', '-s', latest_resf_sha.decode()))
+
+
+    print('[rolling release update] Checking out old rolling branch: ', args.old_rolling_branch)
+    repo.git.checkout(args.old_rolling_branch)
     print('[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD')
     rolling_commit_map = {}
     rollint_commit_map_rev = {}
@@ -46,20 +66,17 @@ if __name__ == '__main__':
             rolling_commit_map[ciq_commit] = upstream_commit
             rollint_commit_map_rev[upstream_commit] = ciq_commit
 
+    print('[rolling release update] Last RESF tag sha: ', latest_resf_sha)
+
     print('{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }')
     print(json.dumps(rolling_commit_map, indent=2))
 
-    
     print('[rolling release update] Checking out new base branch: ', args.new_base_branch)
     repo.git.checkout(args.new_base_branch)
 
-    print('[rolling release update] Finding the new resf_kernel tag the rolling release is based')
     results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                            cwd=args.repo)
-    if results.returncode != 0:
-        print(results.stderr)
-        exit(1)
-    
+                            cwd=repo.working_dir)
+
     print('[rolling release update] Finding the kernel version for the new rolling release')
     new_rolling_branch_kernel = ''
     for line in results.stdout.split(b'\n'):

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -83,8 +83,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Rolling release update')
     parser.add_argument('--repo', help='Repository path', required=True)
     parser.add_argument('--new-base-branch', help='Branch name', required=True)
-    parser.add_argument('--old-rolling-branch', help='Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10', required=True)
+    parser.add_argument('--old-rolling-branch',
+                        help='Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10',
+                        required=True)
     parser.add_argument('--fips-override', help='Override FIPS check abort', action='store_true')
+    parser.add_argument('--verbose-git-show', help='When SHAs are detected for removal do the full git show <sha>',
+                        action='store_true')
     args = parser.parse_args()
 
     repo = git.Repo(args.repo)
@@ -207,15 +211,20 @@ if __name__ == '__main__':
     commits_to_remove = {}
     for ciq_commit, upstream_commit in rolling_commit_map.items():
         if upstream_commit in new_base_commit_map_rev:
-            print(f"Commit {ciq_commit} already present in new base branch")
-            print(repo.git.show(ciq_commit))
+            print(f"- Commit {ciq_commit} already present in new base branch: {repo.git.show('--pretty=oneline', '-s', ciq_commit)}")
             commits_to_remove[ciq_commit] = upstream_commit
+        if ciq_commit in new_base_commit_map:
+            print(f"- CIQ Commit {ciq_commit} already present in new base branch: {repo.git.show('--pretty=oneline', '-s', ciq_commit)}")
+            commits_to_remove[ciq_commit] = upstream_commit
+
 
     print('[rolling release update] Removing commits from the new branch')
     for ciq_commit, upstream_commit in commits_to_remove.items():
         del rolling_commit_map[ciq_commit]
-        print("Removing commit: ", ciq_commit)
-        repo.git.show(ciq_commit)
+        if args.verbose_git_show:
+            print(repo.git.show(ciq_commit))
+        else:
+            print(repo.git.show('--pretty=oneline', '-s', ciq_commit))
 
     print('[rolling release update] Applying the remaining commits to the new branch')
     for ciq_commit, upstream_commit in reversed(rolling_commit_map.items()):


### PR DESCRIPTION
Basically we need a way of creating a new branch that matches our new base and forward port all patches requested by customers.  The normal condition for accepting patches is that we do not take patches unless they have already been accepted upstream kernel.  We utilize a header with a `commit <sha>` pattern to reference it comes from kernel.org.

In this case when our upstream (Rocky Linux community at the moment) consumes a new update to a minor RockyX_y.z or there is a new minor release RockyX_y+1, there is a non zero chance that a commit we're maintaining on the rolling release will have already have been back-ported in the newest release.  So we need to drop patches that are in the main upstream branch and also on our rolling release.  

General proceses
* Tell script where the tree is, what the new base branch (rockyX_y) you want to target and what the last branch you want to roll forward. 
* It will then determine the product of `<product>/<kernel ver>`
* it will Find the neareast common resf rebuild tag `resf_kernel-<vers>`
* Map all commits with `CIQ commit`:`Upstream commit` of the common `resf_` tag and the `rockyX_y` HEAD.
* Find out if any Upstream commits exist in both the above map and the `resf_` tag and the `<product>/<kernel ver>` branch head
  * remove if they exist
  * remove any CIQ shas that exist in both
* attempt to forward port (git cherry-pick) the remaining commits.


NOTE: if the git cherry-pick fails in any way it aborts.
Future work would be to allow an interactive version where it pauses while the engineer fixes up a patch then let it continue. 

## Example
```
[jmaple@devbox kernel-src-tree-tools]
$ python3 rolling-release-update.py --repo ../kernel-src-tree/ \
--new-base-branch rocky8_10 \
--old-rolling-branch sig-cloud-8/4.18.0-553.36.1.el8_10 \
--demo
======================== DEMO MODE ENABLED ==========================
[rolling release update] DEMO mode enabled YOU SHOULD NOT COMMIT THIS
======================== DEMO MODE ENABLED ==========================
[rolling release update] Rolling Product:  sig-cloud-8
[rolling release update] Checking out branch:  sig-cloud-8/4.18.0-553.36.1.el8_10
[rolling release update] Gathering all the RESF kernel Tags
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] Old Rolling Branch Tags:  [b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Checking out branch:  rocky8_10
[rolling release update] Gathering all the RESF kernel Tags
b'0dbf87712115 (HEAD -> rocky8_10, tag: resf_kernel-4.18.0-553.40.1.el8_10, origin/sig-cloud-8/4.18.0-553.40.1.el8_10, origin/rocky8_10, sig-cloud-8/4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
b'26d9a06a4a5f (tag: resf_kernel-4.18.0-553.37.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.37.1.el8_10'
b'4673f9b8360d (tag: resf_kernel-4.18.0-553.36.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10'
b'7e4fb1a14fcd (tag: resf_kernel-4.18.0-553.34.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.34.1.el8_10'
b'72ceaa9ab31e (tag: resf_kernel-4.18.0-553.33.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.33.1.el8_10'
b'0570eb3e10e4 (tag: resf_kernel-4.18.0-553.32.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.32.1.el8_10'
b'657b4d21132b (tag: resf_kernel-4.18.0-553.30.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.30.1.el8_10'
b'c1970aa3f569 (tag: resf_kernel-4.18.0-553.27.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.27.1.el8_10'
b'8bf75aa29fd0 (tag: resf_kernel-4.18.0-553.22.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.22.1.el8_10'
b'ea7f8a5da93b (tag: resf_kernel-4.18.0-553.16.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.16.1.el8_10'
b'2fd9e62e45de (tag: resf_kernel-4.18.0-553.8.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.8.1.el8_10'
b'a2d1b1a06ff8 (tag: resf_kernel-4.18.0-553.5.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.5.1.el8_10'
b'4533b19a3a3e (tag: resf_kernel-4.18.0-553.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.el8_10'
[rolling release update] New Base Branch Tags:  [b'0dbf87712115', b'26d9a06a4a5f', b'4673f9b8360d', b'7e4fb1a14fcd', b'72ceaa9ab31e', b'0570eb3e10e4', b'657b4d21132b', b'c1970aa3f569', b'8bf75aa29fd0', b'ea7f8a5da93b', b'2fd9e62e45de', b'a2d1b1a06ff8', b'4533b19a3a3e']
[rolling release update] Latest RESF tag sha:  b'4673f9b8360d'
"4673f9b8360d5cee804d6161760cb3c82426c2e1 Rebuild rocky8_10 with kernel-4.18.0-553.36.1.el8_10"
[rolling release update] Checking out old rolling branch:  sig-cloud-8/4.18.0-553.36.1.el8_10
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Last RESF tag sha:  b'4673f9b8360d'
[rolling release update] Total Commit in old branch:  7
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "b2097aceefe7b1fbcc642598ff2646384da064d7": "2a38e4ca302280fdcce370ba2bee79bac16c4587",
  "f167c45a2e09529131e1d4803284f1575426ef41": "95bfb35269b2e85cff0dd2c957b2d42ebf95ae5f",
  "06c0ca8aeecdba0f4b0812488526db9e43e470b5": "9a458198eba98b7207669a166e64d04b04cb651b",
  "00efb678ee8f6fa9145c9237f7bce0bd16d0df95": "3e32552652917f10c0aa8ac75cdc8f0b8d257dec",
  "3fc2cafb38462502b6404840a2b9cfcacb11e5d8": "fbf6449f84bf5e4ad09f2c09ee70ed7d629b5ff6",
  "d9f7a6373d2d7becd155cc52c68d3cb24e8b0fd9": "415d832497098030241605c52ea83d4e2cfa7879",
  "b6f3b5ceaceccf9f59be0b4a43313fbc413146f7": ""
}
[rolling release update] Checking out new base branch:  rocky8_10
[rolling release update] Finding the kernel version for the new rolling release
b'0dbf87712115 (HEAD -> rocky8_10, tag: resf_kernel-4.18.0-553.40.1.el8_10, origin/sig-cloud-8/4.18.0-553.40.1.el8_10, origin/rocky8_10, sig-cloud-8/4.18.0-553.40.1.el8_10) Rebuild rocky8_10 with kernel-4.18.0-553.40.1.el8_10'
<re.Match object; span=(0, 72), match=b'0dbf87712115 (HEAD -> rocky8_10, tag: resf_kerne>
[rolling release update} New Branch to create  demo_sig-cloud-8/4.18.0-553.40.1.el8_10
[rolling release update] Check if branch Exists:  demo_sig-cloud-8/4.18.0-553.40.1.el8_10
Branch demo_sig-cloud-8/4.18.0-553.40.1.el8_10 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_demo_sig-cloud-8/4.18.0-553.40.1.el8_10
[rolling release update] Crating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  19
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
Printing first 5 and last 5 commits
{
  "0dbf877121150850feb1245126ccbcf7b752e17d": "",
  "8643975d22afd837b98c19c138dd9ec17fee6ad8": "ecf2b43018da9579842c774b7f35dbe11b5c38dd",
  "0e27ffdddb5bcfe08fb4649eb1fe96bfe059b4dc": "7c9d9223802fbed4dee1ae301661bf346964c9d2",
  "59464a2e36a7b7a3309e133653f5eaa6ee4c9758": "ef8a0f6eab1ca5d1a75c242c5c7b9d386735fa0a",
  "109c9ff2b01e4769bda2e1e50554904a53b7df1d": "ab42fcb511fd9d241bbab7cc3ca04e34e9fc0666"
}
{
  "7553d0fa2b21a6391d59ea447f86a72083b7858f": "d09c05aa35909adb7d29f92f0cd79fdcd1338ef0",
  "f5bae854e2fbe4eb10d1c9942609693c03e1c2fd": "f23a4d6e07570826fe95023ca1aa96a011fa9f84",
  "72add98fbe20dc167e71cba90bed98cfdce43f29": "b5fc07a5fb56216a49e6c1d0b172d5464d99a89b",
  "ced9f6ba12dc48cc29a25d9864eac318665f6b5e": "1cbc11aaa01f80577b67ae02c73ee781112125fd",
  "b6f3b5ceaceccf9f59be0b4a43313fbc413146f7": ""
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
- CIQ Commit b6f3b5ceaceccf9f59be0b4a43313fbc413146f7 already present in new base branch: b6f3b5ceaceccf9f59be0b4a43313fbc413146f7 github actions: Make builds on Merge Request
[rolling release update] Removing commits from the new branch
b6f3b5ceaceccf9f59be0b4a43313fbc413146f7 github actions: Make builds on Merge Request
[rolling release update] Applying the remaining commits to the new branch
Applying commit  "d9f7a6373d2d7becd155cc52c68d3cb24e8b0fd9 locking/atomic: Make test_and_*_bit() ordered on failure"
Applying commit  "3fc2cafb38462502b6404840a2b9cfcacb11e5d8 x86/sev-es: Set x86_virt_bits to the correct value straight away, instead of a two-phase approach"
Applying commit  "00efb678ee8f6fa9145c9237f7bce0bd16d0df95 x86/boot: Move x86_cache_alignment initialization to correct spot"
Applying commit  "06c0ca8aeecdba0f4b0812488526db9e43e470b5 x86/cpu: Allow reducing x86_phys_bits during early_identify_cpu()"
Applying commit  "f167c45a2e09529131e1d4803284f1575426ef41 x86/cpu: Get rid of an unnecessary local variable in get_cpu_address_sizes()"
Applying commit  "b2097aceefe7b1fbcc642598ff2646384da064d7 x86/cpu: Provide default cache line size if not enumerated"
```