### PR TITLE
kernel_remove: init script to remove a specified kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,41 @@ This is the full script that end with the engineer ready to reboot the VM into t
 
 ### kernel_recompile_kabi.sh
 Will only recompile the kernel and check the KABI.
+
+### kernel_remove.sh
+This script is intended to clean up "development" kernels. By
+"development" kernels, the author means such a kernel that was built
+locally for testing if patch(es) for a CVE or customer request apply
+correctly and test them. Mainly, it means kernels installed using
+`make`, instead of as an RPM package.
+
+The script accepts **only one** `kernel release` (`uname -r`) to
+remove. Like so:
+```bash
+$ ./kernel_remove.sh 4.18.0-ciqlts8_6-83208b00c+
++ requested_kernel_to_remove=4.18.0-ciqlts8_6-83208b00c+
+++ rpm -q kernel-core --qf '%{VERSION}-%{RELEASE}\n'
+++ sort --version-sort
+++ tail -1
++ latest_rpm_kernel=4.18.0-372.32.1.el8_6.86ciq_lts.12.1
+++ uname -r
++ current_kernel=4.18.0-372.32.1.el8_6.86ciq_lts.12.1.x86_64
++ '[' -z 4.18.0-ciqlts8_6-83208b00c+ ']'
++ '[' 4.18.0-ciqlts8_6-83208b00c+ == 4.18.0-372.32.1.el8_6.86ciq_lts.12.1 ']'
+++ uname -m
++ '[' 4.18.0-ciqlts8_6-83208b00c+ == 4.18.0-372.32.1.el8_6.86ciq_lts.12.1.x86_64 ']'
++ '[' 4.18.0-ciqlts8_6-83208b00c+ == 4.18.0-372.32.1.el8_6.86ciq_lts.12.1.x86_64 ']'
++ '[' -d /lib/modules/4.18.0-ciqlts8_6-83208b00c+ ']'
++ sudo rm -fr /lib/modules/4.18.0-ciqlts8_6-83208b00c+
++ '[' -d /boot/dtb-4.18.0-ciqlts8_6-83208b00c+ ']'
++ '[' -f /boot/config-4.18.0-ciqlts8_6-83208b00c+ ']'
++ '[' -f /boot/initramfs-4.18.0-ciqlts8_6-83208b00c+.img ']'
++ sudo rm -f /boot/initramfs-4.18.0-ciqlts8_6-83208b00c+.img
++ '[' -f /boot/symvers-4.18.0-ciqlts8_6-83208b00c+.xz ']'
++ '[' -f /boot/symvers-4.18.0-ciqlts8_6-83208b00c+.gz ']'
++ '[' -f /boot/System.map-4.18.0-ciqlts8_6-83208b00c+ ']'
++ sudo rm -f /boot/System.map-4.18.0-ciqlts8_6-83208b00c+
++ '[' -f /boot/vmlinuz-4.18.0-ciqlts8_6-83208b00c+ ']'
++ sudo rm -f /boot/vmlinuz-4.18.0-ciqlts8_6-83208b00c+
++ sudo grubby --remove-kernel=/boot/vmlinuz-4.18.0-ciqlts8_6-83208b00c+
+```

--- a/kernel_remove.sh
+++ b/kernel_remove.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -xeuf -o pipefail
+
+requested_kernel_to_remove="${1:-}"
+rpm_kernels=( $(rpm -q kernel-core --qf "%{VERSION}-%{RELEASE}\n" 2>/dev/null | tr '\n' ' ') )
+current_kernel="$(uname -r)"
+
+if [ -z "${requested_kernel_to_remove}" ]; then
+    echo 'Specify the kernel version'
+    echo 'Look under /lib/modules/ for "correct" versions'
+    exit 1
+fi
+
+for rpm_kernel in "${rpm_kernels[@]}"; do
+    if [ "${requested_kernel_to_remove}" == "${rpm_kernel}" ] || [ "${requested_kernel_to_remove}" == "${rpm_kernel}.$(uname -m)" ]; then
+        echo 'ERROR: Will not remove a kernel installed as an RPM package'
+        exit 1
+    fi
+done
+
+if [ "${requested_kernel_to_remove}" == "${current_kernel}" ]; then
+    echo 'ERROR: Will not remove the current kernel'
+    exit 1
+else
+    # The checks exist to prevent "no such [file|directory] found" "errors" on console
+    # Also helps with error management
+    [ -d "/lib/modules/${requested_kernel_to_remove}" ] && sudo rm -fr "/lib/modules/${requested_kernel_to_remove}"
+    [ -d "/boot/dtb-${requested_kernel_to_remove}" ] && sudo rm -fr "/boot/dtb-${requested_kernel_to_remove}"
+    [ -f "/boot/config-${requested_kernel_to_remove}" ] && sudo rm -f "/boot/config-${requested_kernel_to_remove}"
+    [ -f "/boot/initramfs-${requested_kernel_to_remove}.img" ] && sudo rm -f "/boot/initramfs-${requested_kernel_to_remove}.img"
+    [ -f "/boot/symvers-${requested_kernel_to_remove}.xz" ] && sudo rm -f "/boot/symvers-${requested_kernel_to_remove}.xz"
+    [ -f "/boot/symvers-${requested_kernel_to_remove}.gz" ] && sudo rm -f "/boot/symvers-${requested_kernel_to_remove}.gz"
+    [ -f "/boot/System.map-${requested_kernel_to_remove}" ] && sudo rm -f "/boot/System.map-${requested_kernel_to_remove}"
+    [ -f "/boot/vmlinuz-${requested_kernel_to_remove}" ] && sudo rm -f "/boot/vmlinuz-${requested_kernel_to_remove}"
+    # If $requested_kernel_to_remove is current default kernel, grubby will make the next-in-line kernel default
+    sudo grubby --remove-kernel="/boot/vmlinuz-${requested_kernel_to_remove}"
+fi


### PR DESCRIPTION
This script basically cleans up all the possible paths that might be populated from a `make modules_install` and `make install`. Given that the kernel is removed, the grub entry is also removed with the help of `grubby`.

This is an ad-hoc script created to quickly remove a kernel without much fuss about it.

---

The script only accepts the kernel version and is used like following:

```
$ ./kernel_remove.sh $KERNEL_VERSION

$ ./kernel_remove.sh 4.18.0-ciqlts8_8-6a8fa3030700+
```

And that's all. It will remove all installed files and even remove the grub entry.