### PR TITLE
Intial Commit LT rebasing

### DIFF
--- a/lt_rebase.sh
+++ b/lt_rebase.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -x
+
+CIQ_CONFIG_PATH=ciq/configs
+
+CONFIG_LIST=$(ls ${CIQ_CONFIG_PATH}/*.config)
+
+for config in $CONFIG_LIST; do
+    echo "Rebasing $config"
+    if [[ $config == *"x86_64"* ]]; then
+	echo "Rebasing x86_64 config"
+	cp $config .config
+	make ARCH=x86_64  CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
+	CONFIG_DIFF=$(diff --ignore-matching-lines='^# Linux/x86_64' .config $config | wc -l)
+	if [ $CONFIG_DIFF -eq 0 ]; then
+	    echo "No changes to x86_64 config"
+	else
+	    echo "Changes to x86_64 config"
+	    diff --ignore-matching-lines='^# Linux/x86_64' .config $config
+	    cp .config $config
+	fi
+    elif [[ $config == *"aarch64"* ]]; then
+	echo "Rebaseing aarch64 config"
+	cp $config .config
+	make ARCH=arm64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
+	CONFIG_DIFF=$(diff --ignore-matching-lines='^# Linux/arm64' .config $config | wc -l)
+	if [ $CONFIG_DIFF -eq 0 ]; then
+	    echo "No changes to aarch64 config"
+	else
+	    echo "Changes to aarch64 config"
+	    diff --ignore-matching-lines='^# Linux/aarch64' .config $config
+	    cp .config $config
+	fi
+    else
+	echo "Config ${config} not of supported type"
+	exit 1
+    fi
+done


### PR DESCRIPTION
This checks the configs for a delta after a git rebase as been done. Its very basic that if after the make olddefconfig there is a diff outside of the `linux version line` that it moves the config back into place and lets git sort out the differences.  This script will grow.

```
[jmaple@devbox kernel-src-tree]$ git reset --hard HEAD
HEAD is now at 9dfd84c040df [CIQ] Refresh Configs after making modifications
[jmaple@devbox kernel-src-tree]$ ../kernel-src-tree-tools/lt_rebase.sh
+ CIQ_CONFIG_PATH=ciq/configs
++ ls ciq/configs/kernel-aarch64-64k.config ciq/configs/kernel-aarch64-64k-debug.config ciq/configs/kernel-aarch64.config ciq/configs/kernel-aarch64-debug.config ciq/configs/kernel-x86_64.config ciq/configs/kernel-x86_64-debug.config
+ CONFIG_LIST='ciq/configs/kernel-aarch64-64k.config
ciq/configs/kernel-aarch64-64k-debug.config
ciq/configs/kernel-aarch64.config
ciq/configs/kernel-aarch64-debug.config
ciq/configs/kernel-x86_64.config
ciq/configs/kernel-x86_64-debug.config'
+ for config in $CONFIG_LIST
+ echo 'Rebasing ciq/configs/kernel-aarch64-64k.config'
Rebasing ciq/configs/kernel-aarch64-64k.config
+ [[ ciq/configs/kernel-aarch64-64k.config == *\x\8\6\_\6\4* ]]
+ [[ ciq/configs/kernel-aarch64-64k.config == *\a\a\r\c\h\6\4* ]]
+ echo 'Rebaseing aarch64 config'
Rebaseing aarch64 config
+ cp ciq/configs/kernel-aarch64-64k.config .config
+ make ARCH=arm64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
#
# configuration written to .config
#
++ diff '--ignore-matching-lines=^# Linux/arm64' .config ciq/configs/kernel-aarch64-64k.config
++ wc -l
+ CONFIG_DIFF=0
+ '[' 0 -eq 0 ']'
+ echo 'No changes to aarch64 config'
No changes to aarch64 config
+ for config in $CONFIG_LIST
+ echo 'Rebasing ciq/configs/kernel-aarch64-64k-debug.config'
Rebasing ciq/configs/kernel-aarch64-64k-debug.config
+ [[ ciq/configs/kernel-aarch64-64k-debug.config == *\x\8\6\_\6\4* ]]
+ [[ ciq/configs/kernel-aarch64-64k-debug.config == *\a\a\r\c\h\6\4* ]]
+ echo 'Rebaseing aarch64 config'
Rebaseing aarch64 config
+ cp ciq/configs/kernel-aarch64-64k-debug.config .config
+ make ARCH=arm64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
#
# configuration written to .config
#
++ wc -l
++ diff '--ignore-matching-lines=^# Linux/arm64' .config ciq/configs/kernel-aarch64-64k-debug.config
+ CONFIG_DIFF=0
+ '[' 0 -eq 0 ']'
+ echo 'No changes to aarch64 config'
No changes to aarch64 config
+ for config in $CONFIG_LIST
+ echo 'Rebasing ciq/configs/kernel-aarch64.config'
Rebasing ciq/configs/kernel-aarch64.config
+ [[ ciq/configs/kernel-aarch64.config == *\x\8\6\_\6\4* ]]
+ [[ ciq/configs/kernel-aarch64.config == *\a\a\r\c\h\6\4* ]]
+ echo 'Rebaseing aarch64 config'
Rebaseing aarch64 config
+ cp ciq/configs/kernel-aarch64.config .config
+ make ARCH=arm64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
#
# configuration written to .config
#
++ diff '--ignore-matching-lines=^# Linux/arm64' .config ciq/configs/kernel-aarch64.config
++ wc -l
+ CONFIG_DIFF=0
+ '[' 0 -eq 0 ']'
+ echo 'No changes to aarch64 config'
No changes to aarch64 config
+ for config in $CONFIG_LIST
+ echo 'Rebasing ciq/configs/kernel-aarch64-debug.config'
Rebasing ciq/configs/kernel-aarch64-debug.config
+ [[ ciq/configs/kernel-aarch64-debug.config == *\x\8\6\_\6\4* ]]
+ [[ ciq/configs/kernel-aarch64-debug.config == *\a\a\r\c\h\6\4* ]]
+ echo 'Rebaseing aarch64 config'
Rebaseing aarch64 config
+ cp ciq/configs/kernel-aarch64-debug.config .config
+ make ARCH=arm64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
#
# configuration written to .config
#
++ diff '--ignore-matching-lines=^# Linux/arm64' .config ciq/configs/kernel-aarch64-debug.config
++ wc -l
+ CONFIG_DIFF=6
+ '[' 6 -eq 0 ']'
+ echo 'Changes to aarch64 config'
Changes to aarch64 config
+ diff '--ignore-matching-lines=^# Linux/aarch64' .config ciq/configs/kernel-aarch64-debug.config
0a1
> # arm64
3c4
< # Linux/arm64 6.12.16 Kernel Configuration
---
> # Linux/arm64 6.12.15 Kernel Configuration
7837a7839
> CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
7841d7842
< CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
+ cp .config ciq/configs/kernel-aarch64-debug.config
+ for config in $CONFIG_LIST
+ echo 'Rebasing ciq/configs/kernel-x86_64.config'
Rebasing ciq/configs/kernel-x86_64.config
+ [[ ciq/configs/kernel-x86_64.config == *\x\8\6\_\6\4* ]]
+ echo 'Rebasing x86_64 config'
Rebasing x86_64 config
+ cp ciq/configs/kernel-x86_64.config .config
+ make ARCH=x86_64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
#
# configuration written to .config
#
++ diff '--ignore-matching-lines=^# Linux/x86_64' .config ciq/configs/kernel-x86_64.config
++ wc -l
+ CONFIG_DIFF=0
+ '[' 0 -eq 0 ']'
+ echo 'No changes to x86_64 config'
No changes to x86_64 config
+ for config in $CONFIG_LIST
+ echo 'Rebasing ciq/configs/kernel-x86_64-debug.config'
Rebasing ciq/configs/kernel-x86_64-debug.config
+ [[ ciq/configs/kernel-x86_64-debug.config == *\x\8\6\_\6\4* ]]
+ echo 'Rebasing x86_64 config'
Rebasing x86_64 config
+ cp ciq/configs/kernel-x86_64-debug.config .config
+ make ARCH=x86_64 CROSS_COMPILE=scripts/dummy-tools/ olddefconfig
#
# configuration written to .config
#
++ diff '--ignore-matching-lines=^# Linux/x86_64' .config ciq/configs/kernel-x86_64-debug.config
++ wc -l
+ CONFIG_DIFF=0
+ '[' 0 -eq 0 ']'
+ echo 'No changes to x86_64 config'
No changes to x86_64 config
[jmaple@devbox kernel-src-tree]$ git status
On branch {jmaple}_rebase_ciq-6.12.y
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   ciq/configs/kernel-aarch64-debug.config

no changes added to commit (use "git add" and/or "git commit -a")
[jmaple@devbox kernel-src-tree]$ git diff
diff --git a/ciq/configs/kernel-aarch64-debug.config b/ciq/configs/kernel-aarch64-debug.config
index ce889082816c..3d5912576d75 100644
--- a/ciq/configs/kernel-aarch64-debug.config
+++ b/ciq/configs/kernel-aarch64-debug.config
@@ -1,7 +1,6 @@
-# arm64
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.15 Kernel Configuration
+# Linux/arm64 6.12.16 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (scripts/dummy-tools/gcc)"
 CONFIG_CC_IS_GCC=y
@@ -7836,10 +7835,10 @@ CONFIG_SECURITY_YAMA=y
 # CONFIG_SECURITY_SAFESETID is not set
 CONFIG_SECURITY_LOCKDOWN_LSM=y
 CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y
-CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
 CONFIG_LOCK_DOWN_KERNEL_FORCE_NONE=y
 # CONFIG_LOCK_DOWN_KERNEL_FORCE_INTEGRITY is not set
 # CONFIG_LOCK_DOWN_KERNEL_FORCE_CONFIDENTIALITY is not set
+CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
 CONFIG_SECURITY_LANDLOCK=y
 # CONFIG_SECURITY_IPE is not set
 CONFIG_INTEGRITY=y
```