### PR TITLE
LongTerm Rebase Merge Initialization

### DIFF
--- a/lt_rebase.sh
+++ b/lt_rebase.sh
@@ -8,8 +8,8 @@ if [ -z "$UPSTREAM_REF" ]; then
 fi
 
 git fetch --all
-RES=$(git branch --all | grep ciq-6.12.y-next | wc -l)
-if [ $RES -ne 0 ]; then 
+git show-ref --verify --quiet refs/heads/ciq-6.12.y-next
+if [ $? -eq 0 ]; then 
     echo "cit-6.12.y-next branch already exists, please check status of remote and local branches"
     exit 1
 fi

--- a/lt_rebase_merge.sh
+++ b/lt_rebase_merge.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -x
+
+PR_BRANCH=$1
+TARGET_BRANCH=$2
+NEXT_BRANCH="$2-next"
+NVR_REGEX="[0-9]*\.[0-9]*\.[0-9]*"
+
+if [ -z "$PR_BRANCH" ] || [ -z "$TARGET_BRANCH" ]; then
+  echo "Usage: $0 <pr_branch> <target_branch>"
+  exit 1
+fi
+
+# Check if all branches exist
+git show-ref --verify --quiet refs/heads/$PR_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Branch ${PR_BRANCH} does not exist."
+  exit 1
+fi
+
+git show-ref --verify --quiet refs/heads/$TARGET_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Branch ${TARGET_BRANCH} does not exist."
+  exit 1
+fi
+
+git show-ref --verify --quiet refs/heads/$NEXT_BRANCH
+if [ $? -ne 0] ; then
+  echo "Branch ${NEXT_BRANCH} does not exist."
+  exit 1
+fi
+
+
+#collect all static data fire before making alterations to the local and remote repositories
+PAST_VERSION=$(git describe --tags --abbrev=0 $TARGET_BRANCH | awk -F '-' '{print $2}')
+if [ -z "$PAST_VERSION" ]; then
+  echo "Failed to get a CIQ Tag from ${TARGET_BRANCH}."
+  echo "LastTag: $(git describe --tags --abbrev=0 $TARGET_BRANCH)"
+  exit 1
+fi
+# Check if PAST_VERSION matches the regex
+if ! [[ $PAST_VERSION =~ $NVR_REGEX ]]; then # check if PAST_VERSION matches the regex
+  echo "PAST_VERSION: ${PAST_VERSION} does not match the regex ${NVR_REGEX}"
+  exit 1
+fi
+
+PAST_VERSION_BRANCH="ciq-${PAST_VERSION}"
+echo "PAST_VERSION: $PAST_VERSION"
+echo "PAST_VERSION_BRANCH: $PAST_VERSION_BRANCH"
+
+NEW_GKH_TAG=$(git describe --tags --abbrev=0 $PR_BRANCH | sed 's/^.//g')
+if [ -z "$NEW_GKH_TAG" ]; then
+  echo "Failed to get a GKH Tag from ${PR_BRANCH}."
+  echo "LastTag: $(git describe --tags --abbrev=0 $PR_BRANCH)"
+  exit 1
+fi
+# Check if NEW_GKH_TAG matches the regex
+if ! [[ $NEW_GKH_TAG =~ $NVR_REGEX ]]; then # check if NEW_GKH_TAG matches the regex
+  echo "NEW_GKH_TAG: ${NEW_GKH_TAG} does not match the regex ${NVR_REGEX}"
+  exit 1
+fi
+NEW_CIQ_TAG="ciq_kernel-${NEW_GKH_TAG}-1"
+
+
+# merge PR branch into next branch
+set +x
+echo "git checkout $NEXT_BRANCH"
+git checkout $NEXT_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to checkout ${NEXT_BRANCH}."
+  exit 1
+fi
+
+echo "git pull origin $NEXT_BRANCH"
+git pull origin $NEXT_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to pull ${NEXT_BRANCH}."
+  exit 1
+fi
+
+echo "git merge --ff-only $PR_BRANCH"
+git merge --ff-only $PR_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to merge ${PR_BRANCH} into ${NEXT_BRANCH}."
+  exit 1
+fi
+
+echo "git push origin $NEXT_BRANCH"
+git push origin $NEXT_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to push ${NEXT_BRANCH}."
+  exit 1
+fi
+
+echo "git branch -m $TARGET_BRANCH $PAST_VERSION_BRANCH"
+git branch -m $TARGET_BRANCH $PAST_VERSION_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to rename ${TARGET_BRANCH} to ${PAST_VERSION_BRANCH}."
+  exit 1
+fi
+
+echo "git push origin :$TARGET_BRANCH $PAST_VERSION_BRANCH"
+git push origin :$TARGET_BRANCH $PAST_VERSION_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to delete ${TARGET_BRANCH}."
+  exit 1
+fi
+
+echo "git push origin -u $PAST_VERSION_BRANCH"
+git push origin -u $PAST_VERSION_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to push ${PAST_VERSION_BRANCH}."
+  exit 1
+fi
+
+echo "git branch -m $NEXT_BRANCH $TARGET_BRANCH"
+git branch -m $NEXT_BRANCH $TARGET_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to rename ${NEXT_BRANCH} to ${TARGET_BRANCH}."
+  exit 1
+fi
+
+echo "git push origin :$NEXT_BRANCH $TARGET_BRANCH"
+git push origin :$NEXT_BRANCH $TARGET_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to delete ${NEXT_BRANCH}."
+  exit 1
+fi
+
+echo "git push origin -u $TARGET_BRANCH"
+git push origin -u $TARGET_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to push ${TARGET_BRANCH}."
+  exit 1
+fi
+
+echo "git tag $NEW_CIQ_TAG $TARGET_BRANCH"
+git tag $NEW_CIQ_TAG $TARGET_BRANCH
+if [ $? -ne 0 ]; then
+  echo "Failed to tag ${TARGET_BRANCH} with ${NEW_CIQ_TAG}."
+  exit 1
+fi
+
+echo "git push origin $NEW_CIQ_TAG"
+git push origin $NEW_CIQ_TAG
+if [ $? -ne 0 ]; then
+  echo "Failed to push ${NEW_CIQ_TAG}."
+  exit 1
+fi


### PR DESCRIPTION
Initial commit for others to see programaticaly how the kernel branches can ge juggled to work around the GitHub issues when updates need to be made on the rebase.

Basically if we rebase a `tmp_ciq-6.12.y` rebase the latest GKH stable on it and push it to git hub to be a PR to ciq-6.12.y GitHub gets very cranky. If we for example have to also have to add a commit to update the configs (which includes why the changes are what they are) then GitHUB will not just refuse to merge it but will block github actions as well. If there is not need to update the configs then we can just use a force push to upload the branch.

This is equaly not as ideal but at least GitHub doesn't fight us.

## Test Failure that branch does not exist (exit early)
```
[jmaple@devbox kernel-src-tree]$ ../kernel-src-tree-tools/lt_rebase_merge.sh {automation_tmp}_ciq-6.12.y-nexta ciq-6.12.y
+ PR_BRANCH='{automation_tmp}_ciq-6.12.y-nexta'
+ TARGET_BRANCH=ciq-6.12.y
+ NEXT_BRANCH=ciq-6.12.y-next
+ NVR_REGEX='[0-9]*\.[0-9]*\.[0-9]*'
+ '[' -z '{automation_tmp}_ciq-6.12.y-nexta' ']'
+ '[' -z ciq-6.12.y ']'
+ git show-ref --verify --quiet 'refs/heads/{automation_tmp}_ciq-6.12.y-nexta'
+ '[' 1 -ne 0 ']'
+ echo 'Branch {automation_tmp}_ciq-6.12.y-nexta does not exist.'
Branch {automation_tmp}_ciq-6.12.y-nexta does not exist.
+ exit 1
```

## Test tag is not `X.y.z` NVR
```
[jmaple@devbox kernel-src-tree]$ ../kernel-src-tree-tools/lt_rebase_merge.sh {automation_tmp}_ciq-6.12.y-next ciq-6.12.y
+ PR_BRANCH='{automation_tmp}_ciq-6.12.y-next'
+ TARGET_BRANCH=ciq-6.12.y
+ NEXT_BRANCH=ciq-6.12.y-next
+ NVR_REGEX='[0-9]*\.[0-9]*\.[0-9]*'
+ '[' -z '{automation_tmp}_ciq-6.12.y-next' ']'
+ '[' -z ciq-6.12.y ']'
+ git show-ref --verify --quiet 'refs/heads/{automation_tmp}_ciq-6.12.y-next'
+ git show-ref --verify --quiet refs/heads/ciq-6.12.y
+ git show-ref --verify --quiet refs/heads/ciq-6.12.y-next
++ git describe --tags --abbrev=0 ciq-6.12.y
++ awk -F - '{print $2}'
+ PAST_VERSION=6a.12.18
+ '[' -z 6a.12.18 ']'
+ [[ 6a.12.18 =~ [0-9]*\.[0-9]*\.[0-9]* ]]
+ echo 'PAST_VERSION: 6a.12.18 does not match the regex [0-9]*\.[0-9]*\.[0-9]*'
PAST_VERSION: 6a.12.18 does not match the regex [0-9]*\.[0-9]*\.[0-9]*
+ exit 1
```

## Good Example
```
[jmaple@devbox kernel-src-tree]$ ../kernel-src-tree-tools/lt_rebase_merge.sh {automation_tmp}_ciq-6.12.y-nexta ciq-6.12.y
+ PR_BRANCH='{automation_tmp}_ciq-6.12.y-nexta'
+ TARGET_BRANCH=ciq-6.12.y
+ NEXT_BRANCH=ciq-6.12.y-next
+ NVR_REGEX='[0-9]*\.[0-9]*\.[0-9]*'
+ '[' -z '{automation_tmp}_ciq-6.12.y-nexta' ']'
+ '[' -z ciq-6.12.y ']'
+ git show-ref --verify --quiet 'refs/heads/{automation_tmp}_ciq-6.12.y-nexta'
+ '[' 1 -ne 0 ']'
+ echo 'Branch {automation_tmp}_ciq-6.12.y-nexta does not exist.'
Branch {automation_tmp}_ciq-6.12.y-nexta does not exist.
+ exit 1
[jmaple@devbox kernel-src-tree]$ ../kernel-src-tree-tools/lt_rebase_merge.sh {automation_tmp}_ciq-6.12.y-nexta ciq-6.12.y
+ PR_BRANCH='{automation_tmp}_ciq-6.12.y-nexta'
+ TARGET_BRANCH=ciq-6.12.y
+ NEXT_BRANCH=ciq-6.12.y-next
+ NVR_REGEX='[0-9]*\.[0-9]*\.[0-9]*'
+ '[' -z '{automation_tmp}_ciq-6.12.y-nexta' ']'
+ '[' -z ciq-6.12.y ']'
+ git show-ref --verify --quiet 'refs/heads/{automation_tmp}_ciq-6.12.y-nexta'
+ '[' 1 -ne 0 ']'
+ echo 'Branch {automation_tmp}_ciq-6.12.y-nexta does not exist.'
Branch {automation_tmp}_ciq-6.12.y-nexta does not exist.
+ exit 1
[jmaple@devbox kernel-src-tree]$ ../kernel-src-tree-tools/lt_rebase_merge.sh {automation_tmp}_ciq-6.12.y-next ciq-6.12.y
+ PR_BRANCH='{automation_tmp}_ciq-6.12.y-next'
+ TARGET_BRANCH=ciq-6.12.y
+ NEXT_BRANCH=ciq-6.12.y-next
+ NVR_REGEX='[0-9]*\.[0-9]*\.[0-9]*'
+ '[' -z '{automation_tmp}_ciq-6.12.y-next' ']'
+ '[' -z ciq-6.12.y ']'
+ git show-ref --verify --quiet 'refs/heads/{automation_tmp}_ciq-6.12.y-next'
+ '[' 0 -ne 0 ']'
+ git show-ref --verify --quiet refs/heads/ciq-6.12.y
+ '[' 0 -ne 0 ']'
+ git show-ref --verify --quiet refs/heads/ciq-6.12.y-next
+ '[' 0 -ne '0]'
../kernel-src-tree-tools/lt_rebase_merge.sh: line 28: [: missing `]'
++ git describe --tags --abbrev=0 ciq-6.12.y
++ awk -F - '{print $2}'
+ PAST_VERSION=6.12.18
+ '[' -z 6.12.18 ']'
+ [[ 6.12.18 =~ [0-9]*\.[0-9]*\.[0-9]* ]]
+ PAST_VERSION_BRANCH=ciq-6.12.18
+ echo 'PAST_VERSION: 6.12.18'
PAST_VERSION: 6.12.18
+ echo 'PAST_VERSION_BRANCH: ciq-6.12.18'
PAST_VERSION_BRANCH: ciq-6.12.18
++ sed 's/^.//g'
++ git describe --tags --abbrev=0 '{automation_tmp}_ciq-6.12.y-next'
+ NEW_GKH_TAG=6.12.19
+ '[' -z 6.12.19 ']'
+ [[ 6.12.19 =~ [0-9]*\.[0-9]*\.[0-9]* ]]
+ NEW_CIQ_TAG=ciq_kernel-6.12.19-1
+ set +x
git checkout ciq-6.12.y-next
Switched to branch 'ciq-6.12.y-next'
git pull origin ciq-6.12.y-next
From github.com:ctrliq/kernel-src-tree
 * branch                      ciq-6.12.y-next -> FETCH_HEAD
Already up to date.
git merge --ff-only {automation_tmp}_ciq-6.12.y-next
Updating e9cc806c0152..d2c9c5b73b9f
Fast-forward
 .github/workflows/build-check_aarch64-64k-debug.yml |   34 +
 .github/workflows/build-check_aarch64-64k.yml       |   34 +
 .github/workflows/build-check_aarch64-debug.yml     |   34 +
 .github/workflows/build-check_aarch64.yml           |   34 +
 .github/workflows/build-check_x86_64-debug.yml      |   34 +
 .github/workflows/build-check_x86_64.yml            |   34 +
 arch/x86/kernel/setup.c                             |   16 +-
 ciq/configs/kernel-aarch64-64k-debug.config         | 8891 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ciq/configs/kernel-aarch64-64k.config               | 8823 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ciq/configs/kernel-aarch64-debug.config             | 8897 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ciq/configs/kernel-aarch64.config                   | 8829 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ciq/configs/kernel-x86_64-debug.config              | 9694 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ciq/configs/kernel-x86_64.config                    | 9618 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 drivers/firmware/efi/Makefile                       |    1 +
 drivers/firmware/efi/efi-init.c                     |    5 +-
 drivers/firmware/efi/efi.c                          |  124 ++-
 drivers/firmware/efi/fdtparams.c                    |   12 +-
 drivers/firmware/efi/libstub/fdt.c                  |    6 +
 drivers/firmware/efi/secureboot.c                   |   44 +
 drivers/mtd/devices/phram.c                         |    6 +-
 drivers/mtd/devices/slram.c                         |    9 +-
 include/linux/efi.h                                 |   23 +-
 include/linux/security.h                            |    6 +
 security/lockdown/Kconfig                           |   15 +
 security/lockdown/lockdown.c                        |    2 +-
 25 files changed, 55167 insertions(+), 58 deletions(-)
 create mode 100644 .github/workflows/build-check_aarch64-64k-debug.yml
 create mode 100644 .github/workflows/build-check_aarch64-64k.yml
 create mode 100644 .github/workflows/build-check_aarch64-debug.yml
 create mode 100644 .github/workflows/build-check_aarch64.yml
 create mode 100644 .github/workflows/build-check_x86_64-debug.yml
 create mode 100644 .github/workflows/build-check_x86_64.yml
 create mode 100644 ciq/configs/kernel-aarch64-64k-debug.config
 create mode 100644 ciq/configs/kernel-aarch64-64k.config
 create mode 100644 ciq/configs/kernel-aarch64-debug.config
 create mode 100644 ciq/configs/kernel-aarch64.config
 create mode 100644 ciq/configs/kernel-x86_64-debug.config
 create mode 100644 ciq/configs/kernel-x86_64.config
 create mode 100644 drivers/firmware/efi/secureboot.c
git push origin ciq-6.12.y-next
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:ctrliq/kernel-src-tree.git
   e9cc806c0152..d2c9c5b73b9f  ciq-6.12.y-next -> ciq-6.12.y-next
git branch -m ciq-6.12.y ciq-6.12.18
git push origin :ciq-6.12.y ciq-6.12.18
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0

To github.com:ctrliq/kernel-src-tree.git
 - [deleted]                   ciq-6.12.y
 * [new branch]                ciq-6.12.18 -> ciq-6.12.18
git push origin -u ciq-6.12.18
branch 'ciq-6.12.18' set up to track 'origin/ciq-6.12.18'.
Everything up-to-date
git branch -m ciq-6.12.y-next ciq-6.12.y
git push origin :ciq-6.12.y-next ciq-6.12.y
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0

To github.com:ctrliq/kernel-src-tree.git
 - [deleted]                   ciq-6.12.y-next
 * [new branch]                ciq-6.12.y -> ciq-6.12.y
git push origin -u ciq-6.12.y
branch 'ciq-6.12.y' set up to track 'origin/ciq-6.12.y'.
Everything up-to-date
git tag ciq_kernel-6.12.19-1 ciq-6.12.y
git push origin ciq_kernel-6.12.19-1
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:ctrliq/kernel-src-tree.git
 * [new tag]                   ciq_kernel-6.12.19-1 -> ciq_kernel-6.12.19-1
```