### PR TITLE
kernel_build: Add an option to skip the kABI check

### DIFF
--- a/kernel_build.sh
+++ b/kernel_build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 #set -x
 
+if [ "$1" == "skipkabi" ]; then
+    echo "kABI check will be skipped"
+fi
+
 pwd
 
 BRANCH=$(git branch | grep \* | cut -d ' ' -f2 | sed -r 's/[{}/]/_/g')
@@ -83,12 +87,17 @@ echo "[TIMER]{INSTALL}: $(( $END_INSTALL - $START_INSTALL ))s"
 
 echo "Checking kABI"
 # ../kernel-dist-git/SOURCES/check-kabi -k ../kernel-dist-git/SOURCES/Module.kabi_x86_64 -s Module.symvers || echo "kABI failed"
-KABI_CHECK=$(../kernel-dist-git/SOURCES/check-kabi -k ../kernel-dist-git/SOURCES/Module.kabi_${ARCH} -s Module.symvers)
-if [ $? -ne 0 ]; then
-    echo "Error: kABI check failed"
-    exit 1
+if [ "$1" == "skipkabi" ];  then
+    echo "kABI check skipped"
+else
+    echo "Checking kABI"
+    KABI_CHECK=$(../kernel-dist-git/SOURCES/check-kabi -k ../kernel-dist-git/SOURCES/Module.kabi_${ARCH} -s Module.symvers)
+    if [ $? -ne 0 ]; then
+        echo "Error: kABI check failed"
+        exit 1
+    fi
+    echo "kABI check passed"
 fi
-echo "kABI check passed"
 
 GRUB_INFO=$(sudo grubby --info=ALL | grep -E "^kernel|^index")
 


### PR DESCRIPTION
It's useful in some situations to skip the kABI check. Now it is possible by adding the command line option 'skipkabi'

This change was cherry-picked from kernel-tools 07008e298257ff495a334b050eb0686ba2d7b076 but I reset the author to myself so I can be blamed in the future.