### PR TITLE
lt_rebase_merge: Fix missing `] error

### DIFF
--- a/lt_rebase_merge.sh
+++ b/lt_rebase_merge.sh
@@ -25,7 +25,7 @@ if [ $? -ne 0 ]; then
 fi
 
 git show-ref --verify --quiet refs/heads/$NEXT_BRANCH
-if [ $? -ne 0] ; then
+if [ $? -ne 0 ] ; then
   echo "Branch ${NEXT_BRANCH} does not exist."
   exit 1
 fi


### PR DESCRIPTION
I noticed this error in the confluence example:

../kernel-src-tree-tools/lt_rebase_merge.sh: line 28: [: missing `]'