### PR TITLE
[RR] Update Rolling Release for Rocky10

### DIFF
--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
     for line in results.stdout.split(b'\n'):
         if b'tag: resf_kernel' in line:
             print(line)
-            r = re.match(b'.*(?P<vendor>.*)_kernel-(?P<kernel_ver>[0-9.-]*el[89]_[0-9]*)', line)
+            r = re.match(b'.*(?P<vendor>.*)_kernel-(?P<kernel_ver>[0-9.-]*el[0-9]{1,2}_[0-9]*)', line)
             print(r)
             if r:
                 new_rolling_branch_kernel = r.group('kernel_ver')


### PR DESCRIPTION
The regex was not prepared for Rocky10 Tags in the header.  This likely needs reworked but this is the unblocking commit.

```
[jmaple@devbox kernel-src-tree-tools]$ python3 rolling-release-update.py --repo ../kernel-src-tree/ --new-base-branch rocky10_0 --old-rolling-branch $(git -C ../kernel-src-tree branch --sort=-creatordate --all --list "*sig-cloud-10*" | sed 's/remotes\/origin\///g' | head -n1) | tee ../RR.$(git -C ../kernel-src-tree describe rocky10_0).log
[rolling release update] Rolling Product:  sig-cloud-10
[rolling release update] Checking out branch:  sig-cloud-10/6.12.0-55.19.1.el10_0
[rolling release update] Gathering all the RESF kernel Tags
b'072c27213755 (HEAD -> sig-cloud-10/6.12.0-55.19.1.el10_0, tag: resf_kernel-6.12.0-55.19.1.el10_0, origin/sig-cloud-10/6.12.0-55.19.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.19.1.el10_0'
b'4de01b5748c7 (tag: resf_kernel-6.12.0-55.18.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.18.1.el10_0'
b'71d4955b6748 (tag: resf_kernel-6.12.0-55.17.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.17.1.el10_0'
b'31b726f7bb14 (tag: resf_kernel-6.12.0-55.16.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.16.1.el10_0'
b'defbb7341054 (tag: resf_kernel-6.12.0-55.14.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.14.1.el10_0'
b'abf881e2d199 (tag: resf_kernel-6.12.0-55.13.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.13.1.el10_0'
b'd3c6fc1a3a45 (tag: resf_kernel-6.12.0-55.12.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.12.1.el10_0'
b'ce19035f5d30 (tag: resf_kernel-6.12.0-55.11.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.11.1.el10_0'
[rolling release update] Old Rolling Branch Tags:  [b'072c27213755', b'4de01b5748c7', b'71d4955b6748', b'31b726f7bb14', b'defbb7341054', b'abf881e2d199', b'd3c6fc1a3a45', b'ce19035f5d30']
[rolling release update] Checking out branch:  rocky10_0
[rolling release update] Gathering all the RESF kernel Tags
b'3381775694c1 (HEAD -> rocky10_0, tag: resf_kernel-6.12.0-55.20.1.el10_0, origin/rocky10_0) Rebuild rocky10_0 with kernel-6.12.0-55.20.1.el10_0'
b'072c27213755 (tag: resf_kernel-6.12.0-55.19.1.el10_0, origin/sig-cloud-10/6.12.0-55.19.1.el10_0, sig-cloud-10/6.12.0-55.19.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.19.1.el10_0'
b'4de01b5748c7 (tag: resf_kernel-6.12.0-55.18.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.18.1.el10_0'
b'71d4955b6748 (tag: resf_kernel-6.12.0-55.17.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.17.1.el10_0'
b'31b726f7bb14 (tag: resf_kernel-6.12.0-55.16.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.16.1.el10_0'
b'defbb7341054 (tag: resf_kernel-6.12.0-55.14.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.14.1.el10_0'
b'abf881e2d199 (tag: resf_kernel-6.12.0-55.13.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.13.1.el10_0'
b'd3c6fc1a3a45 (tag: resf_kernel-6.12.0-55.12.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.12.1.el10_0'
b'ce19035f5d30 (tag: resf_kernel-6.12.0-55.11.1.el10_0) Rebuild rocky10_0 with kernel-6.12.0-55.11.1.el10_0'
[rolling release update] New Base Branch Tags:  [b'3381775694c1', b'072c27213755', b'4de01b5748c7', b'71d4955b6748', b'31b726f7bb14', b'defbb7341054', b'abf881e2d199', b'd3c6fc1a3a45', b'ce19035f5d30']
[rolling release update] Latest RESF tag sha:  b'072c27213755'
"072c27213755f894a8400e023a521fd1abb14262 Rebuild rocky10_0 with kernel-6.12.0-55.19.1.el10_0"
[rolling release update] Checking out old rolling branch:  sig-cloud-10/6.12.0-55.19.1.el10_0
[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD
[rolling release update] Last RESF tag sha:  b'072c27213755'
[rolling release update] Total Commit in old branch:  0
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{}
[rolling release update] Checking out new base branch:  rocky10_0
[rolling release update] Finding the kernel version for the new rolling release
b'3381775694c1 (HEAD -> rocky10_0, tag: resf_kernel-6.12.0-55.20.1.el10_0, origin/rocky10_0) Rebuild rocky10_0 with kernel-6.12.0-55.20.1.el10_0'
<re.Match object; span=(0, 71), match=b'3381775694c1 (HEAD -> rocky10_0, tag: resf_kerne>
[rolling release update} New Branch to create  sig-cloud-10/6.12.0-55.20.1.el10_0
[rolling release update] Check if branch Exists:  sig-cloud-10/6.12.0-55.20.1.el10_0
Branch sig-cloud-10/6.12.0-55.20.1.el10_0 does not exists creating
[rolling release update] Creating new branch for PR:  jmaple_sig-cloud-10/6.12.0-55.20.1.el10_0
[rolling release update] Creating Map of all new commits from last rolling release fork
[rolling release update] Total Commit in new branch:  10
{ "CIQ COMMMIT" : "UPSTREAM COMMMIT" }
{
  "3381775694c1e4264886dd2aae5e5ce8dc05747e": "",
  "ccc3544ac2a1b417ff94e53dd0ade3f3d5a2f768": "e3e89178a9f4a80092578af3ff3c8478f9187d59",
  "438548951ea3d9009dffc212b24e3c1c8458b099": "ee62ce7a1d909ccba0399680a03c2dee83bcae95",
  "959fe9bdb180e1be073f047701c234465b7edf50": "cd3c93167da0e760b5819246eae7a4ea30fd014b",
  "39f27f396bf6fbe11e109656e2514b816506803a": "4c2227656d9003f4d77afc76f34dd81b95e4c2c4",
  "7c6318692ed0ddff3b841ba0407452f423dedfc4": "050a3e71ce24c6f18d70679d68056f76375ff51c",
  "b97b5b69723503040ab6fb9ada3f7698b6e09417": "5c977f1023156938915c57d362fddde8fad2b052",
  "97ddc3729639a450b6468d1967aefbe3a9ad11c4": "7734fb4ad98c3fdaf0fde82978ef8638195a5285",
  "2f0a5409de8ff4b6c5ac168d50416776f41ec521": "4862c8861d902d43645a493e441c4478be1c6c44",
  "4414307893dc2d068b61fd93a7fd07a5032a50e8": "087c1faa594fa07a66933d750c0b2610aa1a2946"
}
[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch
[rolling release update] Removing commits from the new branch
[rolling release update] Applying the remaining commits to the new branch
```

Produced Desired Results
Designated by `>` 
```
[jmaple@devbox kernel-src-tree]$ git branch
> jmaple_sig-cloud-10/6.12.0-55.20.1.el10_0
  main
  rocky10_0
  sig-cloud-10/6.12.0-55.19.1.el10_0
> sig-cloud-10/6.12.0-55.20.1.el10_0
```