### PR TITLE
[CIQ HELPERS] Add Multiple Ticket processing

### DIFF
--- a/ciq-cherry-pick.py
+++ b/ciq-cherry-pick.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     print("CIQ custom cherry picker")
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--sha', help='Target SHA1 to cherry-pick')
-    parser.add_argument('--ticket', help='Ticket associated to cherry-pick work')
+    parser.add_argument('--ticket', help='Ticket associated to cherry-pick work, comma separated list is supported.')
     parser.add_argument('--ciq-tag', help="Tags for commit message <feature><-optional modifier> <identifier>.\n"
                         "example: cve CVE-2022-45884 - A patch for a CVE Fix.\n"
                         "         cve-bf CVE-1974-0001 - A bug fix for a CVE currently being patched\n"

--- a/ciq_helpers.py
+++ b/ciq_helpers.py
@@ -112,7 +112,7 @@ def CIQ_cherry_pick_commit_standardization(
     lines: Original SHAS commit message.
     commit: The commit SHA1 that was cherry-picked.
     tags: A list of tags to add to the commit message.
-    jira: The JIRA number to add to the commit message.
+    jira: The JIRA number to add to the commit message, this can be a comma separated list.
     optional_msg: An optional message to add to the commit message.  Traditionally used for `upstream-diff`.
 
     Return: The modified commit message passed in as lines.
@@ -127,7 +127,8 @@ def CIQ_cherry_pick_commit_standardization(
         for tag in tags[::-1]:
             lines.insert(2, f"{tag}\n")
     if jira:
-        lines.insert(2, f"jira {jira}\n")
+        for i in jira.split(","):
+            lines.insert(2, f"jira {i.strip()}\n")
 
     # We Need to indent lines that have email addresss as some tooling in the community
     # will atttempt to read these lines and email everyone on the list.  We do not want


### PR DESCRIPTION
We have some kernel trees that have multiple products which can mean that we have more than one VULN ticket reference (they are per product at the moment). This change allows for us to be able to set multiple jira tickets to a single cherry-pick.  This is in prep for additional automation.

See example commit from future commit to `kernel-src-tree`
```
$ python3 ../kernel-src-tree-tools/ciq-cherry-pick.py --ticket "VULN-136689,VULN-136690" --ciq-tag "cve CVE-2025-38352" --sha f90fff1e152dedf52b932240ebbd670d83330eca

$git log
Author: Jonathan Maple <jmaple@ciq.com>
Date:   Tue Sep 9 12:25:39 2025 -0400

    posix-cpu-timers: fix race between handle_posix_cpu_timers() and posix_cpu_timer_del()

    jira VULN-136690
    jira VULN-136689
    cve CVE-2025-38352
    commit-author Oleg Nesterov <oleg@redhat.com>
    commit f90fff1e152dedf52b932240ebbd670d83330eca
    upstream-diff There where massive merge conflicts due several commits
                  missing from upstream.  Had to manually place and correct
                  do to cherry-pick being extremely greedy with trying to
                  pull changes from this LKML change set:
                  https://lore.kernel.org/all/20200730101404.956367860@linutronix.de/
                  Comment was also adjust to account for the above change
                  set missing.

    If an exiting non-autoreaping task has already passed exit_notify() and
    calls handle_posix_cpu_timers() from IRQ, it can be reaped by its parent
    or debugger right after unlock_task_sighand().
```

Note the upstream diff is unrelated to this change and the cherry-pick was exceptionally greedy.