### PR TITLE
kernel_build: Use HEAD commit too when selecting the default kernel

### DIFF
--- a/kernel_build.sh
+++ b/kernel_build.sh
@@ -140,8 +140,8 @@ fi
 
 GRUB_INFO=$(sudo grubby --info=ALL | grep -E "^kernel|^index")
 
-AWK_RES=$(awk -F '=' -v INDEX=0 -v KERNEL="" -v FINAL_INDEX=0 -v BRANCH="${BRANCH}" \
-    '{if ($2 ~/^[0-9]+$/) {INDEX=$2}} {if ($2 ~BRANCH) {KERNEL=$2; FINAL_INDEX=INDEX}} END {print FINAL_INDEX"  "KERNEL}' \
+AWK_RES=$(awk -F '=' -v INDEX=0 -v KERNEL="" -v FINAL_INDEX=0 -v VERSION="${LOCALVERSION}" \
+    '{if ($2 ~/^[0-9]+$/) {INDEX=$2}} {if ($2 ~VERSION) {KERNEL=$2; FINAL_INDEX=INDEX}} END {print FINAL_INDEX"  "KERNEL}' \
     <<< "${GRUB_INFO}")
 if [ $? -ne 0 ]; then
     echo "Error: awk failed"


### PR DESCRIPTION
In order to boot the kernel that has just been installed, the script tries to find the kernel that matches the BRANCH name in the grub configuration. But if there are multiple matches, the last kernel that matches is the one selected as default version. This happens very often as CVE fixes are done in the same branch for the same person. For example, these 2 kernel match the BRANCH={rnicolescu}_fips-9-compliant/5.14.0-284.30.1:

kernel="/boot/vmlinuz-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-94a90a71b+" kernel="/boot/vmlinuz-5.14.0-rnicolescu_fips-9-compliant_5.14.0-284.30.1-9ee6109a0+"

But the last one is the one that set as default, even though, the HEAD commit is 94a90a71b.

Fix this by matching against LOCALVERSION which takes the HEAD commit hash into account.