### PR TITLE
check_kernel_commits.py: fix regex for finding upstream commit hash

### DIFF
--- a/check_kernel_commits.py
+++ b/check_kernel_commits.py
@@ -204,7 +204,7 @@ def main():
         short_hash, subject = get_short_hash_and_subject(args.repo, sha)
         pr_commit_desc = f"{short_hash} ({subject})"
         msg = get_commit_message(args.repo, sha)
-        upstream_hashes = re.findall(r'^commit\s+([0-9a-fA-F]{12,40})', msg, re.MULTILINE)
+        upstream_hashes = re.findall(r'^commit\s+([0-9a-fA-F]{40})', msg, re.MULTILINE)
         for uhash in upstream_hashes:
             short_uhash = uhash[:12]
             # Ensure the referenced commit in the PR actually exists in the upstream ref.


### PR DESCRIPTION
There are commits upstream that contain references to some commits. One example is:
2d72afb34065 ("netfilter: nf_conntrack: fix crash due to removal of uninitialised entry") that contains this line in the commit message:
"commit 8a75a2c17410 ("netfilter: conntrack: remove unconfirmed list")"

Therefore, the regex that tries to match against
"commit <short_hash/long_hash>" finds both commits as relevant. One is the ustream one, and the other is just a reference that helps understand the commit implementation better. It also happens that this one is exactly at the start of a new line.

Fix this by changing the regex to match against the full legth hash. This works because our script for cherry-picking the upstream commit adds the full commit hash.
Afaik, similar to "Fixes:" entries, commit references in the commit message are always short. If this is not true, this regex can be fixed later.

Another option would have been to match against "cherry picked from <hash>", but this was the easiest and fastest fix.

Note: I believe the for loop should be removed at some point, as there's always one upstream commit reference, unless I am missing something.