### PR TITLE
[JPC] Support cve-bf and cve-pre CVE reference formats

### DIFF
--- a/jira_pr_check.py
+++ b/jira_pr_check.py
@@ -196,11 +196,11 @@ def main():
                             vuln_tickets.append(part.upper())
 
                 # Check for CVE line
-                # Assume format: "cve CVE-YYYY-NNNN"
+                # Assume format: "cve CVE-YYYY-NNNN", "cve-bf CVE-YYYY-NNNN", or "cve-pre CVE-YYYY-NNNN"
                 # There will only be one CVE per line, but possibly multiple CVEs listed
-                if stripped.lower().startswith('cve '):
+                if stripped.lower().startswith(('cve ', 'cve-bf ', 'cve-pre ')):
                     parts = stripped.split()
-                    for part in parts[1:]:  # Skip 'cve' keyword/tag
+                    for part in parts[1:]:  # Skip 'cve'/'cve-bf'/'cve-pre' keyword/tag
                         # CVES always start with CVE-
                         if part.upper().startswith('CVE-'):
                             commit_cves.append(part.upper())


### PR DESCRIPTION
Allow commits to reference CVEs using 'cve-bf CVE-YYYY-NNNN' or 'cve-pre CVE-YYYY-NNNN' in addition to the standard 'cve CVE-YYYY-NNNN' format when validating against JIRA VULN tickets.  Otherwise we will output a warning for these commits even though they are correctly referencing the CVE from the ticket.

Here is an example of the warnings we get today for 'cve-pre' or 'cve-bf' references:
https://github.com/ctrliq/kernel-src-tree/pull/670#issuecomment-3504986345