### PR TITLE
[RI] Change the fuzz factor to 3

### DIFF
--- a/run_interdiff.py
+++ b/run_interdiff.py
@@ -82,7 +82,7 @@ def run_interdiff(repo, backport_sha, upstream_sha, interdiff_path):
             up_path = up.name
 
         interdiff_result = subprocess.run(
-            [interdiff_path, '--fuzzy=0', bp_path, up_path],
+            [interdiff_path, '--fuzzy=3', bp_path, up_path],
             text=True,
             capture_output=True,
             check=False


### PR DESCRIPTION
With the new fuzzy diffing algorithm in interdiff, context differences are always shown. While it is possible for a botched patch application to occur with all 3 context lines fuzzed away, interdiff will still show all the context differences, so there is no risk of lost information.

Use an aggressive fuzz factor of 3 to produce the smallest possible diffs.