### PR TITLE
{rnicolescu} ruff formatting

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,0 +1,38 @@
+name: PR Pre Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - mainline
+
+jobs:
+  pre-commit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Create Python Venv
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+
+      - name: Install Python deps
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip list
+
+      - name: Lint
+        run: |
+          pre-commit install
+          pre-commit run --all-files --show-diff-on-failure --verbose --color=always

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+
+# Ruff stuff:
+.ruff_cache/
+
+venv/
+env/
+.venv/
+.env/
+
+*.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
 
 exclude: |
   (?x)^(
-  jira_pr_check.py |
   release_config.py |
   rolling-release-update.py |
   run_interdiff.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,5 @@ repos:
 
 exclude: |
   (?x)^(
-  rolling-release-update.py |
   run_interdiff.py |
   )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
 exclude: |
   (?x)^(
   ciq-cherry-pick.py |
-  check_kernel_commits.py |
   ciq_helpers.py |
   jira_pr_check.py |
   release_config.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
 
 exclude: |
   (?x)^(
-  release_config.py |
   rolling-release-update.py |
   run_interdiff.py |
   )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
 
 exclude: |
   (?x)^(
-  ciq-cherry-pick.py |
   ciq_helpers.py |
   jira_pr_check.py |
   release_config.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.14.0
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+
+exclude: |
+  (?x)^(
+  ciq-cherry-pick.py |
+  check_kernel_commits.py |
+  ciq_helpers.py |
+  jira_pr_check.py |
+  release_config.py |
+  rolling-release-update.py |
+  run_interdiff.py |
+  )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
 
 exclude: |
   (?x)^(
-  ciq_helpers.py |
   jira_pr_check.py |
   release_config.py |
   rolling-release-update.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,3 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-
-exclude: |
-  (?x)^(
-  run_interdiff.py |
-  )$

--- a/check_kernel_commits.py
+++ b/check_kernel_commits.py
@@ -1,52 +1,59 @@
 #!/usr/bin/env python3
 
 import argparse
-import subprocess
+import os
 import re
+import subprocess
 import sys
 import textwrap
-import os
 from typing import Optional
+
 
 def run_git(repo, args):
     """Run a git command in the given repository and return its output as a string."""
-    result = subprocess.run(['git', '-C', repo] + args, text=True, capture_output=True, check=False)
+    result = subprocess.run(["git", "-C", repo] + args, text=True, capture_output=True, check=False)
     if result.returncode != 0:
         raise RuntimeError(f"Git command failed: {' '.join(args)}\n{result.stderr}")
     return result.stdout
 
+
 def ref_exists(repo, ref):
     """Return True if the given ref exists in the repository, False otherwise."""
     try:
-        run_git(repo, ['rev-parse', '--verify', '--quiet', ref])
+        run_git(repo, ["rev-parse", "--verify", "--quiet", ref])
         return True
     except RuntimeError:
         return False
 
+
 def get_pr_commits(repo, pr_branch, base_branch):
     """Get a list of commit SHAs that are in the PR branch but not in the base branch."""
-    output = run_git(repo, ['rev-list', f'{base_branch}..{pr_branch}'])
+    output = run_git(repo, ["rev-list", f"{base_branch}..{pr_branch}"])
     return output.strip().splitlines()
+
 
 def get_commit_message(repo, sha):
     """Get the commit message for a given commit SHA."""
-    return run_git(repo, ['log', '-n', '1', '--format=%B', sha])
+    return run_git(repo, ["log", "-n", "1", "--format=%B", sha])
+
 
 def get_short_hash_and_subject(repo, sha):
     """Get the abbreviated commit hash and subject for a given commit SHA."""
-    output = run_git(repo, ['log', '-n', '1', '--format=%h%x00%s', sha]).strip()
-    short_hash, subject = output.split('\x00', 1)
+    output = run_git(repo, ["log", "-n", "1", "--format=%h%x00%s", sha]).strip()
+    short_hash, subject = output.split("\x00", 1)
     return short_hash, subject
+
 
 def hash_exists_in_mainline(repo, upstream_ref, hash_):
     """
     Return True if hash_ is reachable from upstream_ref (i.e., is an ancestor of it).
     """
     try:
-        run_git(repo, ['merge-base', '--is-ancestor', hash_, upstream_ref])
+        run_git(repo, ["merge-base", "--is-ancestor", hash_, upstream_ref])
         return True
     except RuntimeError:
         return False
+
 
 def find_fixes_in_mainline(repo, pr_branch, upstream_ref, hash_):
     """
@@ -56,15 +63,13 @@ def find_fixes_in_mainline(repo, pr_branch, upstream_ref, hash_):
     """
     results = []
     # Get all commits with 'Fixes:' in the message
-    output = run_git(repo, [
-        'log', upstream_ref, '--grep', 'Fixes:', '-i', '--format=%H %h %s (%an)%x0a%B%x00'
-    ]).strip()
+    output = run_git(repo, ["log", upstream_ref, "--grep", "Fixes:", "-i", "--format=%H %h %s (%an)%x0a%B%x00"]).strip()
     if not output:
         return []
     # Each commit is separated by a NUL character and a newline
-    commits = output.split('\x00\x0a')
+    commits = output.split("\x00\x0a")
     # Prepare hash prefixes from 12 down to 6
-    hash_prefixes = [hash_[:l] for l in range(12, 5, -1)]
+    hash_prefixes = [hash_[:index] for index in range(12, 5, -1)]
     for commit in commits:
         if not commit.strip():
             continue
@@ -76,75 +81,88 @@ def find_fixes_in_mainline(repo, pr_branch, upstream_ref, hash_):
         full_hash = header.split()[0]
         # Search for Fixes: lines in the commit message
         for line in lines[1:]:
-            m = re.match(r'^\s*Fixes:\s*([0-9a-fA-F]{6,40})', line, re.IGNORECASE)
+            m = re.match(r"^\s*Fixes:\s*([0-9a-fA-F]{6,40})", line, re.IGNORECASE)
             if m:
                 for prefix in hash_prefixes:
                     if m.group(1).lower().startswith(prefix.lower()):
                         if not commit_exists_in_branch(repo, pr_branch, full_hash):
-                            results.append((full_hash, ' '.join(header.split()[1:])))
+                            results.append((full_hash, " ".join(header.split()[1:])))
                         break
             else:
                 continue
     return results
+
 
 def commit_exists_in_branch(repo, pr_branch, upstream_hash_):
     """
     Return True if upstream_hash_ has been backported and it exists in the
     pr branch
     """
-    output = run_git(repo, ['log', pr_branch, '--grep', 'commit ' + upstream_hash_])
+    output = run_git(repo, ["log", pr_branch, "--grep", "commit " + upstream_hash_])
     if not output:
         return False
 
     return True
 
-def wrap_paragraph(text, width=80, initial_indent='', subsequent_indent=''):
+
+def wrap_paragraph(text, width=80, initial_indent="", subsequent_indent=""):
     """Wrap a paragraph of text to the specified width and indentation."""
-    wrapper = textwrap.TextWrapper(width=width,
-                                   initial_indent=initial_indent,
-                                   subsequent_indent=subsequent_indent,
-                                   break_long_words=False,
-                                   break_on_hyphens=False)
+    wrapper = textwrap.TextWrapper(
+        width=width,
+        initial_indent=initial_indent,
+        subsequent_indent=subsequent_indent,
+        break_long_words=False,
+        break_on_hyphens=False,
+    )
     return wrapper.fill(text)
+
 
 def extract_cve_from_message(msg):
     """Extract CVE reference from commit message. Returns CVE ID or None.
     Only matches 'cve CVE-2025-12345', ignores 'cve-bf' and 'cve-pre' variants."""
-    match = re.search(r'(?<!\S)cve\s+(CVE-\d{4}-\d+)', msg, re.IGNORECASE)
+    match = re.search(r"(?<!\S)cve\s+(CVE-\d{4}-\d+)", msg, re.IGNORECASE)
     if match:
         return match.group(1).upper()
     return None
+
 
 def run_cve_search(vulns_repo, kernel_repo, query) -> tuple[bool, Optional[str]]:
     """
     Run the cve_search script from the vulns repo.
     Returns (success, output_message).
     """
-    cve_search_path = os.path.join(vulns_repo, 'scripts', 'cve_search')
+    cve_search_path = os.path.join(vulns_repo, "scripts", "cve_search")
     if not os.path.exists(cve_search_path):
         raise RuntimeError(f"cve_search script not found at {cve_search_path}")
 
     env = os.environ.copy()
-    env['CVEKERNELTREE'] = kernel_repo
+    env["CVEKERNELTREE"] = kernel_repo
 
-    result = subprocess.run([cve_search_path, query],
-                          text=True,
-                          capture_output=True,
-                          check=False,
-                          env=env)
+    result = subprocess.run([cve_search_path, query], text=True, capture_output=True, check=False, env=env)
 
     # cve_search outputs results to stdout
     return result.returncode == 0, result.stdout.strip()
+
 
 def main():
     parser = argparse.ArgumentParser(description="Check upstream references and Fixes: tags in PR branch commits.")
     parser.add_argument("--repo", help="Path to the git repo", required=True)
     parser.add_argument("--pr_branch", help="Name of the PR branch", required=True)
     parser.add_argument("--base_branch", help="Name of the base branch", required=True)
-    parser.add_argument("--markdown", action='store_true', help="Output in Markdown, suitable for GitHub PR comments")
-    parser.add_argument("--upstream-ref", default="origin/kernel-mainline", help="Reference to upstream mainline branch (default: origin/kernel-mainline)")
-    parser.add_argument("--check-cves", action='store_true', help="Check that CVE references in commit messages match upstream commit hashes")
-    parser.add_argument("--vulns-dir", default="../vulns", help="Path to the kernel vulnerabilities repo (default: ../vulns)")
+    parser.add_argument("--markdown", action="store_true", help="Output in Markdown, suitable for GitHub PR comments")
+    parser.add_argument(
+        "--upstream-ref",
+        default="origin/kernel-mainline",
+        help="Reference to upstream mainline branch (default: origin/kernel-mainline)",
+    )
+    parser.add_argument(
+        "--check-cves",
+        action="store_true",
+        help="Check that CVE references in commit messages match upstream commit hashes",
+    )
+    parser.add_argument(
+        "--vulns-dir", default="../vulns", help="Path to the kernel vulnerabilities repo (default: ../vulns)"
+    )
     args = parser.parse_args()
 
     upstream_ref = args.upstream_ref
@@ -158,17 +176,16 @@ def main():
         if os.path.exists(vulns_repo):
             # Repository exists, update it with git pull
             try:
-                run_git(vulns_repo, ['pull'])
+                run_git(vulns_repo, ["pull"])
             except RuntimeError as e:
                 print(f"WARNING: Failed to update vulns repo: {e}")
                 print("Continuing with existing repository...")
         else:
             # Repository doesn't exist, clone it
             try:
-                result = subprocess.run(['git', 'clone', vulns_repo_url, vulns_repo],
-                                      text=True,
-                                      capture_output=True,
-                                      check=False)
+                result = subprocess.run(
+                    ["git", "clone", vulns_repo_url, vulns_repo], text=True, capture_output=True, check=False
+                )
                 if result.returncode != 0:
                     print(f"ERROR: Failed to clone vulns repo: {result.stderr}")
                     sys.exit(1)
@@ -178,9 +195,11 @@ def main():
 
     # Validate that all required refs exist before continuing
     missing_refs = []
-    for refname, refval in [('upstream reference', upstream_ref),
-                            ('PR branch', args.pr_branch),
-                            ('base branch', args.base_branch)]:
+    for refname, refval in [
+        ("upstream reference", upstream_ref),
+        ("PR branch", args.pr_branch),
+        ("base branch", args.base_branch),
+    ]:
         if not ref_exists(args.repo, refval):
             missing_refs.append((refname, refval))
     if missing_refs:
@@ -204,7 +223,7 @@ def main():
         short_hash, subject = get_short_hash_and_subject(args.repo, sha)
         pr_commit_desc = f"{short_hash} ({subject})"
         msg = get_commit_message(args.repo, sha)
-        upstream_hashes = re.findall(r'^commit\s+([0-9a-fA-F]{40})', msg, re.MULTILINE)
+        upstream_hashes = re.findall(r"^commit\s+([0-9a-fA-F]{40})", msg, re.MULTILINE)
         for uhash in upstream_hashes:
             short_uhash = uhash[:12]
             # Ensure the referenced commit in the PR actually exists in the upstream ref.
@@ -218,11 +237,14 @@ def main():
                     )
                 else:
                     prefix = "[NOTFOUND] "
-                    header = (f"{prefix}PR commit {pr_commit_desc} references upstream commit "
-                              f"{short_uhash}, which does not exist in kernel-mainline.")
+                    header = (
+                        f"{prefix}PR commit {pr_commit_desc} references upstream commit "
+                        f"{short_uhash}, which does not exist in kernel-mainline."
+                    )
                     out_lines.append(
-                        wrap_paragraph(header, width=80, initial_indent='',
-                                       subsequent_indent=' ' * len(prefix))  # spaces for '[NOTFOUND] '
+                        wrap_paragraph(
+                            header, width=80, initial_indent="", subsequent_indent=" " * len(prefix)
+                        )  # spaces for '[NOTFOUND] '
                     )
                     out_lines.append("")  # blank line
                 continue
@@ -238,7 +260,7 @@ def main():
                             success, cve_output = run_cve_search(vulns_repo, args.repo, fix_hash)
                             if success:
                                 # Parse the CVE from the result
-                                match = re.search(r'(CVE-\d{4}-\d+)\s+is assigned to git id', cve_output)
+                                match = re.search(r"(CVE-\d{4}-\d+)\s+is assigned to git id", cve_output)
                                 if match:
                                     bugfix_cve = match.group(1)
                                     fix_cves[fix_hash] = bugfix_cve
@@ -265,15 +287,18 @@ def main():
                     )
                 else:
                     prefix = "[FIXES] "
-                    header = (f"{prefix}PR commit {pr_commit_desc} references upstream commit "
-                              f"{short_uhash}, which has Fixes tags:")
+                    header = (
+                        f"{prefix}PR commit {pr_commit_desc} references upstream commit "
+                        f"{short_uhash}, which has Fixes tags:"
+                    )
                     out_lines.append(
-                        wrap_paragraph(header, width=80, initial_indent='',
-                                       subsequent_indent=' ' * len(prefix))  # spaces for '[FIXES] '
+                        wrap_paragraph(
+                            header, width=80, initial_indent="", subsequent_indent=" " * len(prefix)
+                        )  # spaces for '[FIXES] '
                     )
                     out_lines.append("")  # blank line after 'Fixes tags:'
                     for line in fixes_text.splitlines():
-                        out_lines.append('    ' + line)
+                        out_lines.append("    " + line)
                     out_lines.append("")  # blank line
 
             # Check CVE if enabled
@@ -285,8 +310,9 @@ def main():
                     success, cve_output = run_cve_search(vulns_repo, args.repo, uhash)
                     if success:
                         # Parse the output to get the CVE from the result
-                        # Expected format: "CVE-2024-35962 is assigned to git id 65acf6e0501ac8880a4f73980d01b5d27648b956"
-                        match = re.search(r'(CVE-\d{4}-\d+)\s+is assigned to git id', cve_output)
+                        # Expected format: "CVE-2024-35962 is assigned to git id
+                        # 65acf6e0501ac8880a4f73980d01b5d27648b956"
+                        match = re.search(r"(CVE-\d{4}-\d+)\s+is assigned to git id", cve_output)
                         if match:
                             found_cve = match.group(1)
 
@@ -301,11 +327,14 @@ def main():
                                         )
                                     else:
                                         prefix = "[CVE-MISMATCH] "
-                                        header = (f"{prefix}PR commit {pr_commit_desc} references {cve_id} but "
-                                                  f"upstream commit {short_uhash} is associated with {found_cve}")
+                                        header = (
+                                            f"{prefix}PR commit {pr_commit_desc} references {cve_id} but "
+                                            f"upstream commit {short_uhash} is associated with {found_cve}"
+                                        )
                                         out_lines.append(
-                                            wrap_paragraph(header, width=80, initial_indent='',
-                                                           subsequent_indent=' ' * len(prefix))
+                                            wrap_paragraph(
+                                                header, width=80, initial_indent="", subsequent_indent=" " * len(prefix)
+                                            )
                                         )
                                         out_lines.append("")  # blank line
                             else:
@@ -318,11 +347,14 @@ def main():
                                     )
                                 else:
                                     prefix = "[CVE-MISSING] "
-                                    header = (f"{prefix}PR commit {pr_commit_desc} does not reference a CVE but "
-                                              f"upstream commit {short_uhash} is associated with {found_cve}")
+                                    header = (
+                                        f"{prefix}PR commit {pr_commit_desc} does not reference a CVE but "
+                                        f"upstream commit {short_uhash} is associated with {found_cve}"
+                                    )
                                     out_lines.append(
-                                        wrap_paragraph(header, width=80, initial_indent='',
-                                                       subsequent_indent=' ' * len(prefix))
+                                        wrap_paragraph(
+                                            header, width=80, initial_indent="", subsequent_indent=" " * len(prefix)
+                                        )
                                     )
                                     out_lines.append("")  # blank line
                     else:
@@ -337,11 +369,14 @@ def main():
                                 )
                             else:
                                 prefix = "[CVE-NOTFOUND] "
-                                header = (f"{prefix}PR commit {pr_commit_desc} references {cve_id} but "
-                                          f"upstream commit {short_uhash} has no CVE assigned")
+                                header = (
+                                    f"{prefix}PR commit {pr_commit_desc} references {cve_id} but "
+                                    f"upstream commit {short_uhash} has no CVE assigned"
+                                )
                                 out_lines.append(
-                                    wrap_paragraph(header, width=80, initial_indent='',
-                                                   subsequent_indent=' ' * len(prefix))
+                                    wrap_paragraph(
+                                        header, width=80, initial_indent="", subsequent_indent=" " * len(prefix)
+                                    )
                                 )
                                 out_lines.append("")  # blank line
                 except (subprocess.SubprocessError, OSError) as e:
@@ -355,26 +390,25 @@ def main():
                             )
                         else:
                             prefix = "[CVE-ERROR] "
-                            header = (f"{prefix}PR commit {pr_commit_desc} references {cve_id} but "
-                                      f"failed to verify: {e}")
+                            header = f"{prefix}PR commit {pr_commit_desc} references {cve_id} but failed to verify: {e}"
                             out_lines.append(
-                                wrap_paragraph(header, width=80, initial_indent='',
-                                               subsequent_indent=' ' * len(prefix))
+                                wrap_paragraph(header, width=80, initial_indent="", subsequent_indent=" " * len(prefix))
                             )
                             out_lines.append("")  # blank line
 
     if any_findings:
         if args.markdown:
             print("## :mag: Upstream Linux Kernel Commit Check\n")
-            print('\n'.join(out_lines))
+            print("\n".join(out_lines))
             print("*This is an automated message from the kernel commit checker workflow.*")
         else:
-            print('\n'.join(out_lines))
+            print("\n".join(out_lines))
     else:
         if args.markdown:
             print("> ✅ **All referenced commits exist upstream and have no Fixes: tags.**")
         else:
             print("All referenced commits exist upstream and have no Fixes: tags.")
+
 
 if __name__ == "__main__":
     main()

--- a/ciq-cherry-pick.py
+++ b/ciq-cherry-pick.py
@@ -1,44 +1,49 @@
 import argparse
 import os
 import subprocess
+
 import git
-from ciq_helpers import CIQ_cherry_pick_commit_standardization
-from ciq_helpers import CIQ_original_commit_author_to_tag_string
+
+from ciq_helpers import CIQ_cherry_pick_commit_standardization, CIQ_original_commit_author_to_tag_string
+
 # from ciq_helpers import *
 
-MERGE_MSG = git.Repo(os.getcwd()).git_dir + '/MERGE_MSG'
+MERGE_MSG = git.Repo(os.getcwd()).git_dir + "/MERGE_MSG"
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print("CIQ custom cherry picker")
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--sha', help='Target SHA1 to cherry-pick')
-    parser.add_argument('--ticket', help='Ticket associated to cherry-pick work, comma separated list is supported.')
-    parser.add_argument('--ciq-tag', help="Tags for commit message <feature><-optional modifier> <identifier>.\n"
-                        "example: cve CVE-2022-45884 - A patch for a CVE Fix.\n"
-                        "         cve-bf CVE-1974-0001 - A bug fix for a CVE currently being patched\n"
-                        "         cve-pre CVE-1974-0001 - A pre-condition or dependency needed for the CVE\n"
-                        "Multiple tags are separated with a comma. ex: cve CVE-1974-0001, cve CVE-1974-0002\n")
+    parser.add_argument("--sha", help="Target SHA1 to cherry-pick")
+    parser.add_argument("--ticket", help="Ticket associated to cherry-pick work, comma separated list is supported.")
+    parser.add_argument(
+        "--ciq-tag",
+        help="Tags for commit message <feature><-optional modifier> <identifier>.\n"
+        "example: cve CVE-2022-45884 - A patch for a CVE Fix.\n"
+        "         cve-bf CVE-1974-0001 - A bug fix for a CVE currently being patched\n"
+        "         cve-pre CVE-1974-0001 - A pre-condition or dependency needed for the CVE\n"
+        "Multiple tags are separated with a comma. ex: cve CVE-1974-0001, cve CVE-1974-0002\n",
+    )
     args = parser.parse_args()
 
     # Expand the provided SHA1 to the full SHA1 in case it's either abbreviated or an expression
-    git_sha_res = subprocess.run(['git', 'show', '--pretty=%H', '-s', args.sha], stdout=subprocess.PIPE)
+    git_sha_res = subprocess.run(["git", "show", "--pretty=%H", "-s", args.sha], stdout=subprocess.PIPE)
     if git_sha_res.returncode != 0:
         print(f"[FAILED] git show --pretty=%H -s {args.sha}")
         print("Subprocess Call:")
         print(git_sha_res)
         print("")
     else:
-        args.sha = git_sha_res.stdout.decode('utf-8').strip()
+        args.sha = git_sha_res.stdout.decode("utf-8").strip()
 
     tags = []
     if args.ciq_tag is not None:
-        tags = args.ciq_tag.split(',')
+        tags = args.ciq_tag.split(",")
 
     author = CIQ_original_commit_author_to_tag_string(repo_path=os.getcwd(), sha=args.sha)
     if author is None:
         exit(1)
 
-    git_res = subprocess.run(['git', 'cherry-pick', '-nsx', args.sha])
+    git_res = subprocess.run(["git", "cherry-pick", "-nsx", args.sha])
     if git_res.returncode != 0:
         print(f"[FAILED] git cherry-pick -nsx {args.sha}")
         print("       Manually resolve conflict and include `upstream-diff` tag in commit message")
@@ -47,7 +52,7 @@ if __name__ == '__main__':
         print("")
 
     print(os.getcwd())
-    subprocess.run(['cp', MERGE_MSG, f'{MERGE_MSG}.bak'])
+    subprocess.run(["cp", MERGE_MSG, f"{MERGE_MSG}.bak"])
 
     tags.append(author)
 
@@ -58,11 +63,11 @@ if __name__ == '__main__':
 
     print(f"Cherry Pick New Message for {args.sha}")
     for line in new_msg:
-        print(line.strip('\n'))
+        print(line.strip("\n"))
     print(f"\n Original Message located here: {MERGE_MSG}.bak")
 
     with open(MERGE_MSG, "w") as file:
         file.writelines(new_msg)
 
     if git_res.returncode == 0:
-        subprocess.run(['git', 'commit', '-F', MERGE_MSG])
+        subprocess.run(["git", "commit", "-F", MERGE_MSG])

--- a/ciq_helpers.py
+++ b/ciq_helpers.py
@@ -3,10 +3,11 @@
 
 # CIQ Kernel Tools  function library
 
-import git
 import os
 import re
 import subprocess
+
+import git
 
 
 def process_full_commit_message(commit):
@@ -84,9 +85,7 @@ def get_backport_commit_data(repo, branch, common_ancestor, allow_duplicates=Fal
 
     for line in lines:
         if len(commit) > 0 and line.startswith(b"commit "):
-            upstream_commit, cves, tickets, upstream_subject, repo_commit = (
-                process_full_commit_message(commit)
-            )
+            upstream_commit, cves, tickets, upstream_subject, repo_commit = process_full_commit_message(commit)
             if upstream_commit in upstream_commits:
                 print(f"WARNING: {upstream_commit} already in upstream_commits")
                 if not allow_duplicates:
@@ -104,9 +103,7 @@ def get_backport_commit_data(repo, branch, common_ancestor, allow_duplicates=Fal
     return upstream_commits, True
 
 
-def CIQ_cherry_pick_commit_standardization(
-    lines, commit, tags=None, jira="", optional_msg=""
-):
+def CIQ_cherry_pick_commit_standardization(lines, commit, tags=None, jira="", optional_msg=""):
     """Standardize CIQ the cherry-pick commit message.
     Parameters:
     lines: Original SHAS commit message.
@@ -159,13 +156,17 @@ def CIQ_original_commit_author_to_tag_string(repo_path, sha):
 
     Return: String for Tag
     """
-    git_auth_res = subprocess.run(['git', 'show', '--pretty="%aN <%aE>"', '--no-patch', sha], stderr=subprocess.PIPE,
-                                  stdout=subprocess.PIPE, cwd=repo_path)
+    git_auth_res = subprocess.run(
+        ["git", "show", '--pretty="%aN <%aE>"', "--no-patch", sha],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        cwd=repo_path,
+    )
     if git_auth_res.returncode != 0:
         print(f"[FAILED] git show --pretty='%aN <%aE>' --no-patch {sha}")
         print(f"[FAILED][STDERR:{git_auth_res.returncode}] {git_auth_res.stderr.decode('utf-8')}")
         return None
-    return "commit-author " + git_auth_res.stdout.decode('utf-8').replace('\"', '').strip()
+    return "commit-author " + git_auth_res.stdout.decode("utf-8").replace('"', "").strip()
 
 
 def repo_init(repo):

--- a/jira_pr_check.py
+++ b/jira_pr_check.py
@@ -5,23 +5,22 @@ import os
 import re
 import subprocess
 import sys
-from jira import JIRA
-from release_config import release_map, jira_field_map
 
-CVE_PATTERN = r'CVE-\d{4}-\d{4,7}'
+from jira import JIRA
+
+from release_config import jira_field_map, release_map
+
+CVE_PATTERN = r"CVE-\d{4}-\d{4,7}"
 
 # Reverse lookup: field name -> custom field ID
 jira_field_reverse = {v: k for k, v in jira_field_map.items()}
+
 
 def restore_git_branch(original_branch, kernel_src_tree):
     """Restore the original git branch in case of errors."""
     try:
         subprocess.run(
-            ["git", "checkout", original_branch],
-            cwd=kernel_src_tree,
-            check=True,
-            capture_output=True,
-            text=True
+            ["git", "checkout", original_branch], cwd=kernel_src_tree, check=True, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
         print(f"ERROR: Failed to restore original branch {original_branch}: {e.stderr}")
@@ -31,7 +30,7 @@ def restore_git_branch(original_branch, kernel_src_tree):
 def main():
     parser = argparse.ArgumentParser(
         description="Validate PR Commits against JIRA VULN Tickets",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     # This is a necessary requirement at the moment to allow multiple different JIRA creds from the same user
     parser.add_argument(
@@ -73,9 +72,9 @@ def main():
         print(f"ERROR: Kernel source tree path does not exist: {args.kernel_src_tree}")
         sys.exit(1)
 
-    jira_url = args.jira_url or os.environ.get('JIRA_URL')
-    jira_user = args.jira_user or os.environ.get('JIRA_API_USER')
-    jira_key = args.jira_key or os.environ.get('JIRA_API_TOKEN')
+    jira_url = args.jira_url or os.environ.get("JIRA_URL")
+    jira_user = args.jira_user or os.environ.get("JIRA_API_USER")
+    jira_key = args.jira_key or os.environ.get("JIRA_API_TOKEN")
 
     if not all([jira_url, jira_user, jira_key]):
         print("ERROR: JIRA credentials not provided. Set via --jira-* args or environment variables.")
@@ -92,9 +91,7 @@ def main():
     try:
         # Get current branch to restore later
         result = subprocess.run(
-            ["git", "branch", "--show-current"],
-            cwd=args.kernel_src_tree,
-            check=True, capture_output=True, text=True
+            ["git", "branch", "--show-current"], cwd=args.kernel_src_tree, check=True, capture_output=True, text=True
         )
         original_branch = result.stdout.strip()
     except subprocess.CalledProcessError as e:
@@ -104,11 +101,7 @@ def main():
     # Checkout the merge target branch first to ensure it exists
     try:
         subprocess.run(
-            ["git", "checkout", args.merge_target],
-            cwd=args.kernel_src_tree,
-            check=True,
-            capture_output=True,
-            text=True
+            ["git", "checkout", args.merge_target], cwd=args.kernel_src_tree, check=True, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
         print(f"ERROR: Failed to checkout merge target branch {args.merge_target}: {e.stderr}")
@@ -119,11 +112,7 @@ def main():
     # Checkout the PR branch
     try:
         subprocess.run(
-            ["git", "checkout", args.pr_branch],
-            cwd=args.kernel_src_tree,
-            check=True,
-            capture_output=True,
-            text=True
+            ["git", "checkout", args.pr_branch], cwd=args.kernel_src_tree, check=True, capture_output=True, text=True
         )
     except subprocess.CalledProcessError as e:
         print(f"ERROR: Failed to checkout PR branch {args.pr_branch}: {e.stderr}")
@@ -137,13 +126,13 @@ def main():
             cwd=args.kernel_src_tree,
             check=True,
             capture_output=True,
-            text=True
+            text=True,
         )
     except subprocess.CalledProcessError as e:
         print(f"ERROR: failed to get commits: {e.stderr}")
         sys.exit(1)
 
-    commit_shas = result.stdout.strip().split('\n') if result.stdout.strip() else []
+    commit_shas = result.stdout.strip().split("\n") if result.stdout.strip() else []
 
     # Parse each commit and extract header
     commits_data = []
@@ -158,14 +147,14 @@ def main():
                 cwd=args.kernel_src_tree,
                 check=True,
                 capture_output=True,
-                text=True
+                text=True,
             )
         except subprocess.CalledProcessError as e:
             print(f"ERROR: Failed to get commits: {e.stderr}")
             sys.exit(1)
 
         commit_msg = result.stdout.strip()
-        lines = commit_msg.split('\n')
+        lines = commit_msg.split("\n")
 
         # Extract summary line (first line)
         summary = lines[0] if lines else ""
@@ -189,23 +178,23 @@ def main():
                 stripped = line.strip()
 
                 # Check for jira line with VULN
-                if stripped.lower().startswith('jira ') and 'vuln-' in stripped.lower():
+                if stripped.lower().startswith("jira ") and "vuln-" in stripped.lower():
                     parts = stripped.split()
                     for part in parts[1:]:  # Skip 'jira' keyword
-                        if part.upper().startswith('VULN-'):
+                        if part.upper().startswith("VULN-"):
                             vuln_tickets.append(part.upper())
 
                 # Check for CVE line
                 # Assume format: "cve CVE-YYYY-NNNN", "cve-bf CVE-YYYY-NNNN", or "cve-pre CVE-YYYY-NNNN"
                 # There will only be one CVE per line, but possibly multiple CVEs listed
-                if stripped.lower().startswith(('cve ', 'cve-bf ', 'cve-pre ')):
+                if stripped.lower().startswith(("cve ", "cve-bf ", "cve-pre ")):
                     parts = stripped.split()
                     for part in parts[1:]:  # Skip 'cve'/'cve-bf'/'cve-pre' keyword/tag
                         # CVES always start with CVE-
-                        if part.upper().startswith('CVE-'):
+                        if part.upper().startswith("CVE-"):
                             commit_cves.append(part.upper())
 
-        header = '\n'.join(header_lines)
+        header = "\n".join(header_lines)
 
         # Check VULN tickets against merge target
         lts_match = None
@@ -218,7 +207,7 @@ def main():
 
                     # Get LTS product
                     lts_product_field = issue.get_field(jira_field_reverse["LTS Product"])
-                    if hasattr(lts_product_field, 'value'):
+                    if hasattr(lts_product_field, "value"):
                         lts_product = lts_product_field.value
                     else:
                         lts_product = str(lts_product_field) if lts_product_field else None
@@ -248,48 +237,60 @@ def main():
                         commit_cves_set = set(commit_cves)
                         if not commit_cves_set.issubset(ticket_cves):
                             missing_in_ticket = commit_cves_set - ticket_cves
-                            issues_list.append({
-                                'type': 'error',
-                                'vuln_id': vuln_id,
-                                'message': f"CVE mismatch - Commit has {', '.join(sorted(missing_in_ticket))} but VULN ticket does not"
-                            })
+                            issues_list.append(
+                                {
+                                    "type": "error",
+                                    "vuln_id": vuln_id,
+                                    "message": f"CVE mismatch - Commit has {', '.join(sorted(missing_in_ticket))} but VULN ticket does not",
+                                }
+                            )
                         if not ticket_cves.issubset(commit_cves_set):
                             missing_in_commit = ticket_cves - commit_cves_set
-                            issues_list.append({
-                                'type': 'warning',
-                                'vuln_id': vuln_id,
-                                'message': f"VULN ticket has {', '.join(sorted(missing_in_commit))} but commit does not"
-                            })
+                            issues_list.append(
+                                {
+                                    "type": "warning",
+                                    "vuln_id": vuln_id,
+                                    "message": f"VULN ticket has {', '.join(sorted(missing_in_commit))} but commit does not",
+                                }
+                            )
                     elif commit_cves and not ticket_cves:
-                        issues_list.append({
-                            'type': 'warning',
-                            'vuln_id': vuln_id,
-                            'message': f"Commit has CVEs {', '.join(sorted(commit_cves))} but VULN ticket has no CVEs"
-                        })
+                        issues_list.append(
+                            {
+                                "type": "warning",
+                                "vuln_id": vuln_id,
+                                "message": f"Commit has CVEs {', '.join(sorted(commit_cves))} but VULN ticket has no CVEs",
+                            }
+                        )
                     elif ticket_cves and not commit_cves:
-                        issues_list.append({
-                            'type': 'warning',
-                            'vuln_id': vuln_id,
-                            'message': f"VULN ticket has CVEs {', '.join(sorted(ticket_cves))} but commit has no CVEs"
-                        })
+                        issues_list.append(
+                            {
+                                "type": "warning",
+                                "vuln_id": vuln_id,
+                                "message": f"VULN ticket has CVEs {', '.join(sorted(ticket_cves))} but commit has no CVEs",
+                            }
+                        )
 
                     # Check ticket status
                     status = issue.fields.status.name
                     if status != "In Progress":
-                        issues_list.append({
-                            'type': 'error',
-                            'vuln_id': vuln_id,
-                            'message': f"Status is '{status}', expected 'In Progress'"
-                        })
+                        issues_list.append(
+                            {
+                                "type": "error",
+                                "vuln_id": vuln_id,
+                                "message": f"Status is '{status}', expected 'In Progress'",
+                            }
+                        )
 
                     # Check if time is logged
                     time_spent = issue.fields.timespent
                     if not time_spent or time_spent == 0:
-                        issues_list.append({
-                            'type': 'warning',
-                            'vuln_id': vuln_id,
-                            'message': 'No time logged - please log time manually'
-                        })
+                        issues_list.append(
+                            {
+                                "type": "warning",
+                                "vuln_id": vuln_id,
+                                "message": "No time logged - please log time manually",
+                            }
+                        )
 
                     # Check if LTS product matches merge target branch
                     if lts_product and lts_product in release_map:
@@ -298,39 +299,43 @@ def main():
                             lts_match = True
                         else:
                             lts_match = False
-                            issues_list.append({
-                                'type': 'error',
-                                'vuln_id': vuln_id,
-                                'message': f"LTS product '{lts_product}' expects branch '{expected_branch}', but merge target is '{args.merge_target}'"
-                            })
+                            issues_list.append(
+                                {
+                                    "type": "error",
+                                    "vuln_id": vuln_id,
+                                    "message": f"LTS product '{lts_product}' expects branch '{expected_branch}', but merge target is '{args.merge_target}'",
+                                }
+                            )
                     else:
-                        issues_list.append({
-                            'type': 'error',
-                            'vuln_id': vuln_id,
-                            'message': f"LTS product '{lts_product}' not found in release_map"
-                        })
+                        issues_list.append(
+                            {
+                                "type": "error",
+                                "vuln_id": vuln_id,
+                                "message": f"LTS product '{lts_product}' not found in release_map",
+                            }
+                        )
 
                 except Exception as e:
-                    issues_list.append({
-                        'type': 'error',
-                        'vuln_id': vuln_id,
-                        'message': f"Failed to retrieve ticket: {e}"
-                    })
+                    issues_list.append(
+                        {"type": "error", "vuln_id": vuln_id, "message": f"Failed to retrieve ticket: {e}"}
+                    )
 
-        commits_data.append({
-            'sha': sha,
-            'summary': summary,
-            'header': header,
-            'full_message': commit_msg,
-            'vuln_tickets': vuln_tickets,
-            'lts_match': lts_match,
-            'issues': issues_list
-        })
+        commits_data.append(
+            {
+                "sha": sha,
+                "summary": summary,
+                "header": header,
+                "full_message": commit_msg,
+                "vuln_tickets": vuln_tickets,
+                "lts_match": lts_match,
+                "issues": issues_list,
+            }
+        )
 
     # Print formatted results
     print("\n## JIRA PR Check Results\n")
 
-    commits_with_issues = [c for c in commits_data if c['issues']]
+    commits_with_issues = [c for c in commits_data if c["issues"]]
     has_errors = False
 
     if commits_with_issues:
@@ -341,8 +346,8 @@ def main():
             print(f"**Summary:** {commit['summary']}\n")
 
             # Group issues by type
-            errors = [i for i in commit['issues'] if i['type'] == 'error']
-            warnings = [i for i in commit['issues'] if i['type'] == 'warning']
+            errors = [i for i in commit["issues"] if i["type"] == "error"]
+            warnings = [i for i in commit["issues"] if i["type"] == "warning"]
 
             if errors:
                 has_errors = True
@@ -370,7 +375,6 @@ def main():
     restore_git_branch(original_branch, kernel_src_tree=args.kernel_src_tree)
 
     return jira, commits_data
-
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+# This is not an installable project at the moment.
+# This is used to control dependencies and liter configuration
+[project]
+name = "kernel-src-tree-tools"
+requires-python = ">=3.10"
+readme = "README.md"
+version = "0.0.1"
+dependencies = [
+]
+
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "ruff",
+	]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+# Ignore the `line-too-long` for now
+ignore = ["E501"]
+
+[tool.setuptools]
+# suppress error: Multiple top-level packages
+py-modules = []

--- a/release_config.py
+++ b/release_config.py
@@ -25,49 +25,29 @@ jira_field_map = {
 
 # Product to branch mapping
 release_map = {
-    "lts-9.4": {
-        "src_git_branch": "ciqlts9_4",
-        "dist_git_branch": "lts94-9",
-        "mock_config": "rocky-lts94"
-    },
-    "lts-9.2": {
-        "src_git_branch": "ciqlts9_2",
-        "dist_git_branch": "lts92-9",
-        "mock_config": "rocky-lts92"
-    },
-    "lts-8.8": {
-        "src_git_branch": "ciqlts8_8",
-        "dist_git_branch": "lts88-8",
-        "mock_config": "rocky-lts88"
-    },
-    "lts-8.6": {
-        "src_git_branch": "ciqlts8_6",
-        "dist_git_branch": "lts86-8",
-        "mock_config": "rocky-lts86"
-    },
-    "cbr-7.9": {
-        "src_git_branch": "ciqcbr7_9",
-        "dist_git_branch": "cbr79-7",
-        "mock_config": "centos-cbr79"
-    },
+    "lts-9.4": {"src_git_branch": "ciqlts9_4", "dist_git_branch": "lts94-9", "mock_config": "rocky-lts94"},
+    "lts-9.2": {"src_git_branch": "ciqlts9_2", "dist_git_branch": "lts92-9", "mock_config": "rocky-lts92"},
+    "lts-8.8": {"src_git_branch": "ciqlts8_8", "dist_git_branch": "lts88-8", "mock_config": "rocky-lts88"},
+    "lts-8.6": {"src_git_branch": "ciqlts8_6", "dist_git_branch": "lts86-8", "mock_config": "rocky-lts86"},
+    "cbr-7.9": {"src_git_branch": "ciqcbr7_9", "dist_git_branch": "cbr79-7", "mock_config": "centos-cbr79"},
     "fips-9.2": {
         "src_git_branch": "fips-9-compliant/5.14.0-284.30.1",
         "dist_git_branch": "el92-fips-compliant-9",
-        "mock_config": "rocky-fips92"
+        "mock_config": "rocky-fips92",
     },
     "fips-8.10": {
         "src_git_branch": "fips-8-compliant/4.18.0-553.16.1",
         "dist_git_branch": "el810-fips-compliant-8",
-        "mock_config": "rocky-fips810-553-depot"
+        "mock_config": "rocky-fips810-553-depot",
     },
     "fips-8.6": {
         "src_git_branch": "fips-8-compliant/4.18.0-553.16.1",
         "dist_git_branch": "el86-fips-compliant-8",
-        "mock_config": "rocky-fips86-553-depot"
+        "mock_config": "rocky-fips86-553-depot",
     },
     "fipslegacy-8.6": {
         "src_git_branch": "fips-legacy-8-compliant/4.18.0-425.13.1",
         "dist_git_branch": "fips-compliant8",
-        "mock_config": "rocky-lts86-fips"
-    }
+        "mock_config": "rocky-lts86-fips",
+    },
 }

--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -1,14 +1,22 @@
 import argparse
 import json
 import os
-import subprocess
 import re
+import subprocess
+
 import git
 
-FIPS_PROTECTED_DIRECTORIES=[b'arch/x86/crypto/', b'crypto/asymmetric_keys/', b'crypto/', b'drivers/crypto/',
-                            b'drivers/char/random.c', b'include/crypto']
+FIPS_PROTECTED_DIRECTORIES = [
+    b"arch/x86/crypto/",
+    b"crypto/asymmetric_keys/",
+    b"crypto/",
+    b"drivers/crypto/",
+    b"drivers/char/random.c",
+    b"include/crypto",
+]
 
 DEBUG = False
+
 
 def find_common_tag(old_tags, new_tags):
     for tag in old_tags:
@@ -16,74 +24,82 @@ def find_common_tag(old_tags, new_tags):
             return tag
     return None
 
+
 def get_branch_tag_sha_list(repo, branch):
-    print('[rolling release update] Checking out branch: ', branch)
+    print("[rolling release update] Checking out branch: ", branch)
     repo.git.checkout(branch)
-    results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                            cwd=repo.working_dir)
+    results = subprocess.run(
+        ["git", "log", "--decorate", "--oneline"], stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=repo.working_dir
+    )
     if results.returncode != 0:
         print(results.stderr)
         exit(1)
 
-    print('[rolling release update] Gathering all the RESF kernel Tags')
+    print("[rolling release update] Gathering all the RESF kernel Tags")
     tags = []
-    for line in results.stdout.split(b'\n'):
-        if b'tag: resf_kernel' in line:
-            tags.append(line.split(b' ')[0])
+    for line in results.stdout.split(b"\n"):
+        if b"tag: resf_kernel" in line:
+            tags.append(line.split(b" ")[0])
 
     # Print summary instead of all tags
     if len(tags) > 0:
-        print(f'[rolling release update] Found {len(tags)} RESF kernel tags')
+        print(f"[rolling release update] Found {len(tags)} RESF kernel tags")
         if DEBUG:
             for line_tag in tags:
-                print(f'  {line_tag.decode()}')
+                print(f"  {line_tag.decode()}")
 
     return tags
 
+
 def check_for_fips_protected_changes(repo, branch, common_tag):
-    print('[rolling release update] Checking for FIPS protected changes')
+    print("[rolling release update] Checking for FIPS protected changes")
     repo.git.checkout(branch)
-    print(f'[rolling release update] Getting SHAS {common_tag.decode()}..HEAD')
-    results = subprocess.run(['git', 'log', '--pretty=%H', f'{common_tag.decode()}..HEAD'], stderr=subprocess.PIPE,
-                             stdout=subprocess.PIPE, cwd=repo.working_dir)
+    print(f"[rolling release update] Getting SHAS {common_tag.decode()}..HEAD")
+    results = subprocess.run(
+        ["git", "log", "--pretty=%H", f"{common_tag.decode()}..HEAD"],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        cwd=repo.working_dir,
+    )
     if results.returncode != 0:
         print(results.stderr)
         exit(1)
 
-    num_commits = len(results.stdout.split(b'\n'))
-    print('[rolling release update] Number of commits to check: ', num_commits)
+    num_commits = len(results.stdout.split(b"\n"))
+    print("[rolling release update] Number of commits to check: ", num_commits)
     shas_to_check = {}
     commits_checked = 0
 
-    progress_interval = max(1, num_commits//10)
+    progress_interval = max(1, num_commits // 10)
 
-    print('[rolling release update] Checking modifications of shas')
+    print("[rolling release update] Checking modifications of shas")
     if DEBUG:
-        print(results.stdout.split(b'\n'))
-    for sha in results.stdout.split(b'\n'):
+        print(results.stdout.split(b"\n"))
+    for sha in results.stdout.split(b"\n"):
         commits_checked += 1
         if commits_checked % progress_interval == 0:
-            print(f'[rolling release update] Checked {commits_checked} of {num_commits} commits')
-        if sha == b'':
+            print(f"[rolling release update] Checked {commits_checked} of {num_commits} commits")
+        if sha == b"":
             continue
-        res = subprocess.run(['git', 'show', '--name-only', '--pretty=%H %s',  f'{sha.decode()}'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                                cwd=repo.working_dir)
+        res = subprocess.run(
+            ["git", "show", "--name-only", "--pretty=%H %s", f"{sha.decode()}"],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            cwd=repo.working_dir,
+        )
         if res.returncode != 0:
             print(res)
             print(res.stderr)
             exit(1)
 
-        sha_hash_and_subject = b''
+        sha_hash_and_subject = b""
         touched_fips_files = set()
-        is_rebuild = False
 
-        for line in res.stdout.split(b'\n'):
-            if sha_hash_and_subject == b'':
+        for line in res.stdout.split(b"\n"):
+            if sha_hash_and_subject == b"":
                 sha_hash_and_subject = line
-                if b'Rebuild rocky' in line:
-                    is_rebuild = True
                 continue
-            if line == b'':
+            if line == b"":
                 continue
 
             add_to_check = False
@@ -91,217 +107,241 @@ def check_for_fips_protected_changes(repo, branch, common_tag):
             for dir in FIPS_PROTECTED_DIRECTORIES:
                 if line.startswith(dir):
                     if DEBUG:
-                        print(f'FIPS protected directory {dir} change found in commit {sha}')
+                        print(f"FIPS protected directory {dir} change found in commit {sha}")
                         print(sha_hash_and_subject)
                     add_to_check = True
                     if dir not in touched_fips_files:
                         touched_fips_files.add(dir)
 
             if add_to_check:
-                shas_to_check[sha_hash_and_subject.split(b' ')[0]] = touched_fips_files
+                shas_to_check[sha_hash_and_subject.split(b" ")[0]] = touched_fips_files
 
         if touched_fips_files:
-            print(f'[rolling release update] Checked commit {sha} touched {len(touched_fips_files)} FIPS protected files')
+            print(
+                f"[rolling release update] Checked commit {sha} touched {len(touched_fips_files)} FIPS protected files"
+            )
             for f in touched_fips_files:
-                print(f'  - {f}')
-        sha_hash_and_subject = b''
+                print(f"  - {f}")
+        sha_hash_and_subject = b""
 
-    print(f'[rolling release update] {len(shas_to_check)} of {num_commits} commits have FIPS protected changes')
+    print(f"[rolling release update] {len(shas_to_check)} of {num_commits} commits have FIPS protected changes")
 
     return shas_to_check
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Rolling release update')
-    parser.add_argument('--repo', help='Repository path', required=True)
-    parser.add_argument('--new-base-branch', help='Branch name', required=True)
-    parser.add_argument('--old-rolling-branch',
-                        help='Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10',
-                        required=True)
-    parser.add_argument('--fips-override', help='Override FIPS check abort', action='store_true')
-    parser.add_argument('--verbose-git-show', help='When SHAs are detected for removal do the full git show <sha>',
-                        action='store_true')
-    parser.add_argument('--demo', help='DEMO mode, will make a new set of branches with demo_ prepended',
-                        action='store_true')
-    parser.add_argument('--debug', help='Enable debug output', action='store_true')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Rolling release update")
+    parser.add_argument("--repo", help="Repository path", required=True)
+    parser.add_argument("--new-base-branch", help="Branch name", required=True)
+    parser.add_argument(
+        "--old-rolling-branch",
+        help="Branch name for old rolling release: ex: sig-cloud-8/4.18.0-553.33.1.el8_10",
+        required=True,
+    )
+    parser.add_argument("--fips-override", help="Override FIPS check abort", action="store_true")
+    parser.add_argument(
+        "--verbose-git-show", help="When SHAs are detected for removal do the full git show <sha>", action="store_true"
+    )
+    parser.add_argument(
+        "--demo", help="DEMO mode, will make a new set of branches with demo_ prepended", action="store_true"
+    )
+    parser.add_argument("--debug", help="Enable debug output", action="store_true")
     args = parser.parse_args()
 
     if args.demo:
-        print('======================== DEMO MODE ENABLED ==========================')
-        print('[rolling release update] DEMO mode enabled YOU SHOULD NOT COMMIT THIS')
-        print('======================== DEMO MODE ENABLED ==========================')
+        print("======================== DEMO MODE ENABLED ==========================")
+        print("[rolling release update] DEMO mode enabled YOU SHOULD NOT COMMIT THIS")
+        print("======================== DEMO MODE ENABLED ==========================")
 
     if args.debug:
         DEBUG = True
-        print('======================== DEBUG MODE ENABLED ==========================')
-        print('[rolling release update] Debug mode enabled')
-        print('======================== DEBUG MODE ENABLED ==========================')
+        print("======================== DEBUG MODE ENABLED ==========================")
+        print("[rolling release update] Debug mode enabled")
+        print("======================== DEBUG MODE ENABLED ==========================")
 
     repo = git.Repo(args.repo)
 
-    rolling_product = args.old_rolling_branch.split('/')[0]
-    print('[rolling release update] Rolling Product: ', rolling_product)
+    rolling_product = args.old_rolling_branch.split("/")[0]
+    print("[rolling release update] Rolling Product: ", rolling_product)
 
     old_rolling_branch_tags = get_branch_tag_sha_list(repo, args.old_rolling_branch)
     if DEBUG:
-        print('[rolling release update] Old Rolling Branch Tags: ', old_rolling_branch_tags)
+        print("[rolling release update] Old Rolling Branch Tags: ", old_rolling_branch_tags)
 
     new_base_branch_tags = get_branch_tag_sha_list(repo, args.new_base_branch)
     if DEBUG:
-        print('[rolling release update] New Base Branch Tags: ', new_base_branch_tags)
+        print("[rolling release update] New Base Branch Tags: ", new_base_branch_tags)
 
     latest_resf_sha = find_common_tag(old_rolling_branch_tags, new_base_branch_tags)
-    print('[rolling release update] Latest RESF tag sha: ', latest_resf_sha)
-    print(repo.git.show('--pretty="%H %s"', '-s', latest_resf_sha.decode()))
+    print("[rolling release update] Latest RESF tag sha: ", latest_resf_sha)
+    print(repo.git.show('--pretty="%H %s"', "-s", latest_resf_sha.decode()))
 
-    print('[rolling release update] Checking for FIPS protected changes between the common tag and HEAD')
+    print("[rolling release update] Checking for FIPS protected changes between the common tag and HEAD")
     shas_to_check = check_for_fips_protected_changes(repo, args.new_base_branch, latest_resf_sha)
     if shas_to_check and args.fips_override is False:
-        for sha,dir in shas_to_check.items():
+        for sha, dir in shas_to_check.items():
             print(f"## Commit {sha.decode()}")
-            print('\'\'\'')
+            print("'''")
             dir_list = []
             for d in dir:
                 dir_list.append(d.decode())
             print(repo.git.show(sha.decode(), dir_list))
-            print('\'\'\'')
-        print('[rolling release update] FIPS protected changes found between the common tag and HEAD')
-        print('[rolling release update] Please Contact the CIQ FIPS / Security team for further instructions')
-        print('[rolling release update] Exiting')
+            print("'''")
+        print("[rolling release update] FIPS protected changes found between the common tag and HEAD")
+        print("[rolling release update] Please Contact the CIQ FIPS / Security team for further instructions")
+        print("[rolling release update] Exiting")
         exit(1)
 
-
-    print('[rolling release update] Checking out old rolling branch: ', args.old_rolling_branch)
+    print("[rolling release update] Checking out old rolling branch: ", args.old_rolling_branch)
     repo.git.checkout(args.old_rolling_branch)
-    print('[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD')
+    print(
+        "[rolling release update] Finding the CIQ Kernel and Associated Upstream commits between the last resf tag and HEAD"
+    )
     rolling_commit_map = {}
     rollint_commit_map_rev = {}
-    rolling_commits = repo.git.log(f'{latest_resf_sha.decode()}..HEAD')
-    for line in rolling_commits.split('\n'):
-        if line.startswith('commit '):
-            ciq_commit = line.split('commit ')[1]
-            rolling_commit_map[ciq_commit] = ''
-        if line.startswith('    commit '):
-            upstream_commit = line.split('    commit ')[1]
+    rolling_commits = repo.git.log(f"{latest_resf_sha.decode()}..HEAD")
+    for line in rolling_commits.split("\n"):
+        if line.startswith("commit "):
+            ciq_commit = line.split("commit ")[1]
+            rolling_commit_map[ciq_commit] = ""
+        if line.startswith("    commit "):
+            upstream_commit = line.split("    commit ")[1]
             rolling_commit_map[ciq_commit] = upstream_commit
             rollint_commit_map_rev[upstream_commit] = ciq_commit
 
-    print('[rolling release update] Last RESF tag sha: ', latest_resf_sha)
+    print("[rolling release update] Last RESF tag sha: ", latest_resf_sha)
 
-    print(f'[rolling release update] Total commits in old branch: {len(rolling_commit_map)}')
+    print(f"[rolling release update] Total commits in old branch: {len(rolling_commit_map)}")
     if DEBUG:
         print('{ "CIQ COMMIT" : "UPSTREAM COMMIT" }')
         if len(rolling_commit_map) > 10:
-            print('Printing first 5 and last 5 commits')
+            print("Printing first 5 and last 5 commits")
             print(json.dumps({k: rolling_commit_map[k] for k in list(rolling_commit_map)[:5]}, indent=2))
             print(json.dumps({k: rolling_commit_map[k] for k in list(rolling_commit_map)[-5:]}, indent=2))
         else:
             print(json.dumps(rolling_commit_map, indent=2))
 
-    print('[rolling release update] Checking out new base branch: ', args.new_base_branch)
+    print("[rolling release update] Checking out new base branch: ", args.new_base_branch)
     repo.git.checkout(args.new_base_branch)
 
-    results = subprocess.run(['git', 'log', '--decorate', '--oneline'], stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                            cwd=repo.working_dir)
+    results = subprocess.run(
+        ["git", "log", "--decorate", "--oneline"], stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=repo.working_dir
+    )
 
-    print('[rolling release update] Finding the kernel version for the new rolling release')
-    new_rolling_branch_kernel = ''
-    for line in results.stdout.split(b'\n'):
-        if b'tag: resf_kernel' in line:
+    print("[rolling release update] Finding the kernel version for the new rolling release")
+    new_rolling_branch_kernel = ""
+    for line in results.stdout.split(b"\n"):
+        if b"tag: resf_kernel" in line:
             if DEBUG:
                 print(line)
-            r = re.match(b'.*(?P<vendor>.*)_kernel-(?P<kernel_ver>[0-9.-]*el[0-9]{1,2}_[0-9]*)', line)
+            r = re.match(b".*(?P<vendor>.*)_kernel-(?P<kernel_ver>[0-9.-]*el[0-9]{1,2}_[0-9]*)", line)
             if r:
-                new_rolling_branch_kernel = r.group('kernel_ver')
+                new_rolling_branch_kernel = r.group("kernel_ver")
                 if DEBUG:
-                    print(f'[rolling release update] Matched kernel version: {new_rolling_branch_kernel.decode()}')
+                    print(f"[rolling release update] Matched kernel version: {new_rolling_branch_kernel.decode()}")
             break
 
     if args.demo:
-        new_rolling_branch_kernel = f'demo_{rolling_product}/{new_rolling_branch_kernel.decode()}'
+        new_rolling_branch_kernel = f"demo_{rolling_product}/{new_rolling_branch_kernel.decode()}"
     else:
-        new_rolling_branch_kernel = f'{rolling_product}/{new_rolling_branch_kernel.decode()}'
-    print(f'[rolling release update] New Branch to create: {new_rolling_branch_kernel}')
-    
+        new_rolling_branch_kernel = f"{rolling_product}/{new_rolling_branch_kernel.decode()}"
+    print(f"[rolling release update] New Branch to create: {new_rolling_branch_kernel}")
+
     if DEBUG:
-        print(f'[rolling release update] Check if branch exists: {new_rolling_branch_kernel}')
-    results = subprocess.run(['git', 'show-ref', '--quiet', f'refs/heads/{new_rolling_branch_kernel}'],
-                            stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=args.repo)
+        print(f"[rolling release update] Check if branch exists: {new_rolling_branch_kernel}")
+    results = subprocess.run(
+        ["git", "show-ref", "--quiet", f"refs/heads/{new_rolling_branch_kernel}"],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        cwd=args.repo,
+    )
     if results.returncode == 0:
-        print(f'[rolling release update] ERROR: Branch {new_rolling_branch_kernel} already exists')
+        print(f"[rolling release update] ERROR: Branch {new_rolling_branch_kernel} already exists")
         exit(1)
     else:
-        print(f'[rolling release update] Creating new branch: {new_rolling_branch_kernel}')
-        results = subprocess.run(['git', 'checkout', '-b', new_rolling_branch_kernel], stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE, cwd=args.repo)
+        print(f"[rolling release update] Creating new branch: {new_rolling_branch_kernel}")
+        results = subprocess.run(
+            ["git", "checkout", "-b", new_rolling_branch_kernel],
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            cwd=args.repo,
+        )
     if results.returncode != 0:
         print(results.stderr)
         exit(1)
 
-    print('[rolling release update] Creating new branch for PR: ', f"{os.getlogin()}_{new_rolling_branch_kernel}")
-    results = subprocess.run(['git', 'checkout', '-b', f"{os.getlogin()}_{new_rolling_branch_kernel}"], stderr=subprocess.PIPE,
-                            stdout=subprocess.PIPE, cwd=args.repo)
+    print("[rolling release update] Creating new branch for PR: ", f"{os.getlogin()}_{new_rolling_branch_kernel}")
+    results = subprocess.run(
+        ["git", "checkout", "-b", f"{os.getlogin()}_{new_rolling_branch_kernel}"],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        cwd=args.repo,
+    )
     if results.returncode != 0:
         print(results.stderr)
         exit(1)
 
-    
-    print('[rolling release update] Creating Map of all new commits from last rolling release fork')
+    print("[rolling release update] Creating Map of all new commits from last rolling release fork")
     new_base_commit_map = {}
     new_base_commit_map_rev = {}
-    new_base_commits = repo.git.log(f'{latest_resf_sha.decode()}..HEAD')
-    for line in new_base_commits.split('\n'):
-        if line.startswith('commit '):
-            ciq_commit = line.split('commit ')[1]
-            new_base_commit_map[ciq_commit] = ''
-        if line.startswith('    commit '):
-            upstream_commit = line.split('    commit ')[1]
+    new_base_commits = repo.git.log(f"{latest_resf_sha.decode()}..HEAD")
+    for line in new_base_commits.split("\n"):
+        if line.startswith("commit "):
+            ciq_commit = line.split("commit ")[1]
+            new_base_commit_map[ciq_commit] = ""
+        if line.startswith("    commit "):
+            upstream_commit = line.split("    commit ")[1]
             new_base_commit_map[ciq_commit] = upstream_commit
             new_base_commit_map_rev[upstream_commit] = ciq_commit
 
-    print(f'[rolling release update] Total commits in new branch: {len(new_base_commit_map)}')
+    print(f"[rolling release update] Total commits in new branch: {len(new_base_commit_map)}")
     if DEBUG:
         print('{ "CIQ COMMIT" : "UPSTREAM COMMIT" }')
         if len(new_base_commit_map) > 10:
-            print('Printing first 5 and last 5 commits')
+            print("Printing first 5 and last 5 commits")
             print(json.dumps({k: new_base_commit_map[k] for k in list(new_base_commit_map)[:5]}, indent=2))
             print(json.dumps({k: new_base_commit_map[k] for k in list(new_base_commit_map)[-5:]}, indent=2))
         else:
             print(json.dumps(new_base_commit_map, indent=2))
 
-    print('[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch')
+    print(
+        "[rolling release update] Checking if any of the commits from the old rolling release are already present in the new base branch"
+    )
     commits_to_remove = {}
     for ciq_commit, upstream_commit in rolling_commit_map.items():
         if upstream_commit in new_base_commit_map_rev:
-            print(f"- Commit {ciq_commit} already present in new base branch: {repo.git.show('--pretty=oneline', '-s', ciq_commit)}")
+            print(
+                f"- Commit {ciq_commit} already present in new base branch: {repo.git.show('--pretty=oneline', '-s', ciq_commit)}"
+            )
             commits_to_remove[ciq_commit] = upstream_commit
         if ciq_commit in new_base_commit_map:
-            print(f"- CIQ Commit {ciq_commit} already present in new base branch: {repo.git.show('--pretty=oneline', '-s', ciq_commit)}")
+            print(
+                f"- CIQ Commit {ciq_commit} already present in new base branch: {repo.git.show('--pretty=oneline', '-s', ciq_commit)}"
+            )
             commits_to_remove[ciq_commit] = upstream_commit
 
-
-    print(f'[rolling release update] Found {len(commits_to_remove)} duplicate commits to remove')
+    print(f"[rolling release update] Found {len(commits_to_remove)} duplicate commits to remove")
     if commits_to_remove:
-        print('[rolling release update] Removing duplicate commits:')
+        print("[rolling release update] Removing duplicate commits:")
         for ciq_commit, upstream_commit in commits_to_remove.items():
             del rolling_commit_map[ciq_commit]
             if args.verbose_git_show:
                 print(repo.git.show(ciq_commit))
             else:
-                print(f'  - {repo.git.show("--pretty=oneline", "-s", ciq_commit)}')
+                print(f"  - {repo.git.show('--pretty=oneline', '-s', ciq_commit)}")
 
-    print(f'[rolling release update] Applying {len(rolling_commit_map)} remaining commits to the new branch')
+    print(f"[rolling release update] Applying {len(rolling_commit_map)} remaining commits to the new branch")
     commits_applied = 0
     for ciq_commit, upstream_commit in reversed(rolling_commit_map.items()):
         commits_applied += 1
-        commit_info = repo.git.show('--pretty=%h %s', '-s', ciq_commit)
-        print(f'  [{commits_applied}/{len(rolling_commit_map)}] {commit_info}')
-        result = subprocess.run(['git', 'cherry-pick', '-s', ciq_commit], stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE, cwd=args.repo)
+        commit_info = repo.git.show("--pretty=%h %s", "-s", ciq_commit)
+        print(f"  [{commits_applied}/{len(rolling_commit_map)}] {commit_info}")
+        result = subprocess.run(
+            ["git", "cherry-pick", "-s", ciq_commit], stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=args.repo
+        )
         if result.returncode != 0:
-            print(f'[rolling release update] ERROR: Failed to cherry-pick commit {ciq_commit}')
-            print(result.stderr.decode('utf-8'))
+            print(f"[rolling release update] ERROR: Failed to cherry-pick commit {ciq_commit}")
+            print(result.stderr.decode("utf-8"))
             exit(1)
 
-    print(f'[rolling release update] Successfully applied all {commits_applied} commits')
-
+    print(f"[rolling release update] Successfully applied all {commits_applied} commits")

--- a/run_interdiff.py
+++ b/run_interdiff.py
@@ -1,71 +1,78 @@
 #!/usr/bin/env python3
 
 import argparse
-import subprocess
-import re
-import sys
 import os
+import re
+import subprocess
+import sys
 import tempfile
+
 
 def run_git(repo, args):
     """Run a git command in the given repository and return its output as a string."""
-    result = subprocess.run(['git', '-C', repo] + args, text=True, capture_output=True, check=False)
+    result = subprocess.run(["git", "-C", repo] + args, text=True, capture_output=True, check=False)
     if result.returncode != 0:
         raise RuntimeError(f"Git command failed: {' '.join(args)}\n{result.stderr}")
     return result.stdout
 
+
 def ref_exists(repo, ref):
     """Return True if the given ref exists in the repository, False otherwise."""
     try:
-        run_git(repo, ['rev-parse', '--verify', '--quiet', ref])
+        run_git(repo, ["rev-parse", "--verify", "--quiet", ref])
         return True
     except RuntimeError:
         return False
 
+
 def get_pr_commits(repo, pr_branch, base_branch):
     """Get a list of commit SHAs that are in the PR branch but not in the base branch."""
     try:
-        output = run_git(repo, ['rev-list', f'{base_branch}..{pr_branch}'])
+        output = run_git(repo, ["rev-list", f"{base_branch}..{pr_branch}"])
         return output.strip().splitlines()
     except RuntimeError as e:
         raise RuntimeError(f"Failed to get commits from {base_branch}..{pr_branch}: {e}")
 
+
 def get_commit_message(repo, sha):
     """Get the commit message for a given commit SHA."""
     try:
-        return run_git(repo, ['log', '-n', '1', '--format=%B', sha])
+        return run_git(repo, ["log", "-n", "1", "--format=%B", sha])
     except RuntimeError as e:
         raise RuntimeError(f"Failed to get commit message for {sha}: {e}")
+
 
 def get_short_hash_and_subject(repo, sha):
     """Get the abbreviated commit hash and subject for a given commit SHA."""
     try:
-        output = run_git(repo, ['log', '-n', '1', '--format=%h%x00%s', sha]).strip()
-        short_hash, subject = output.split('\x00', 1)
+        output = run_git(repo, ["log", "-n", "1", "--format=%h%x00%s", sha]).strip()
+        short_hash, subject = output.split("\x00", 1)
         return short_hash, subject
     except RuntimeError as e:
         raise RuntimeError(f"Failed to get short hash and subject for {sha}: {e}")
 
+
 def extract_upstream_hash(msg):
     """Extract the upstream commit hash from a commit message.
     Looks for lines like 'commit <hash>' in the commit message."""
-    match = re.search(r'^commit\s+([0-9a-fA-F]{12,40})', msg, re.MULTILINE)
+    match = re.search(r"^commit\s+([0-9a-fA-F]{12,40})", msg, re.MULTILINE)
     if match:
         return match.group(1)
     return None
+
 
 def run_interdiff(repo, backport_sha, upstream_sha, interdiff_path):
     """Run interdiff comparing the backport commit with the upstream commit.
     Returns (success, output) tuple."""
     # Generate format-patch for backport commit
     try:
-        backport_patch = run_git(repo, ['format-patch', '-1', '--stdout', backport_sha])
+        backport_patch = run_git(repo, ["format-patch", "-1", "--stdout", backport_sha])
     except RuntimeError as e:
         return False, f"Failed to generate patch for backport commit: {e}"
 
     # Generate format-patch for upstream commit
     try:
-        upstream_patch = run_git(repo, ['format-patch', '-1', '--stdout', upstream_sha])
+        upstream_patch = run_git(repo, ["format-patch", "-1", "--stdout", upstream_sha])
     except RuntimeError as e:
         return False, f"Failed to generate patch for upstream commit: {e}"
 
@@ -73,19 +80,16 @@ def run_interdiff(repo, backport_sha, upstream_sha, interdiff_path):
     bp_path = None
     up_path = None
     try:
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.patch', delete=False) as bp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".patch", delete=False) as bp:
             bp.write(backport_patch)
             bp_path = bp.name
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.patch', delete=False) as up:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".patch", delete=False) as up:
             up.write(upstream_patch)
             up_path = up.name
 
         interdiff_result = subprocess.run(
-            [interdiff_path, '--fuzzy=3', bp_path, up_path],
-            text=True,
-            capture_output=True,
-            check=False
+            [interdiff_path, "--fuzzy=3", bp_path, up_path], text=True, capture_output=True, check=False
         )
 
         # Check for interdiff errors (non-zero return code other than 1)
@@ -107,21 +111,21 @@ def run_interdiff(repo, backport_sha, upstream_sha, interdiff_path):
         if up_path and os.path.exists(up_path):
             os.unlink(up_path)
 
+
 def find_interdiff():
     """Find interdiff in system PATH. Returns path if found, None otherwise."""
-    result = subprocess.run(['which', 'interdiff'], capture_output=True, text=True, check=False)
+    result = subprocess.run(["which", "interdiff"], capture_output=True, text=True, check=False)
     if result.returncode == 0:
         return result.stdout.strip()
     return None
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        description="Run interdiff on backported kernel commits to compare with upstream."
-    )
+    parser = argparse.ArgumentParser(description="Run interdiff on backported kernel commits to compare with upstream.")
     parser.add_argument("--repo", help="Path to the Linux kernel git repo", required=True)
     parser.add_argument("--pr_branch", help="Git reference to the feature branch", required=True)
     parser.add_argument("--base_branch", help="Branch the feature branch is based off of", required=True)
-    parser.add_argument("--markdown", action='store_true', help="Format output with markdown")
+    parser.add_argument("--markdown", action="store_true", help="Format output with markdown")
     parser.add_argument("--interdiff", help="Path to interdiff executable (default: system interdiff)", default=None)
     args = parser.parse_args()
 
@@ -145,8 +149,7 @@ def main():
 
     # Validate that all required refs exist
     missing_refs = []
-    for refname, refval in [('PR branch', args.pr_branch),
-                            ('base branch', args.base_branch)]:
+    for refname, refval in [("PR branch", args.pr_branch), ("base branch", args.base_branch)]:
         if not ref_exists(args.repo, refval):
             missing_refs.append((refname, refval))
 
@@ -210,7 +213,7 @@ def main():
             any_differences = True
             if args.markdown:
                 out_lines.append(f"- ⚠️ PR commit `{pr_commit_desc}` → upstream `{upstream_hash[:12]}`")
-                out_lines.append(f"  **Differences found:**\n")
+                out_lines.append("  **Differences found:**\n")
                 out_lines.append("```diff")
                 out_lines.append(output)
                 out_lines.append("```\n")
@@ -226,15 +229,16 @@ def main():
     if any_differences:
         if args.markdown:
             print("## :mag: Interdiff Analysis\n")
-            print('\n'.join(out_lines))
+            print("\n".join(out_lines))
             print("*This is an automated interdiff check for backported commits.*")
         else:
-            print('\n'.join(out_lines))
+            print("\n".join(out_lines))
     else:
         if args.markdown:
             print("> ✅ **All backported commits match their upstream counterparts.**")
         else:
             print("All backported commits match their upstream counterparts.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add support for linting tools and dependencies management.
The file needed are:

- pyproject.toml. This is used for managing dependencies and configuration
into a single file. At the moment, it is not written to be able to
install this project as a proper package, but it can be changed in the future.

- .pre-commit-config.yaml. This will run Ruff's linter and
formatter via pre-commit.
Initially all py files were excluded. Following commits removed them from the exclude
rule one by one. 

Local usage:
- to install packages run:
```
python -m pip install -e ".[dev]"
```

You can also use a virtual environment.
- Install git hook for pre-commit: 
```
pre-commit install
```

It also added github action to check pre-commit, in case developers
do not have the pre commit hook installed as recommended.

To setup Ruff with your current editor of choice, check out the
official doc https://docs.astral.sh/ruff/editors/setup/

For vim, I personally use 
```
Plug 'dense-analysis/ale'
```
...

```
" Disable linter for C file (gets rid of that annoying include error)
let g:ale_linters = {
\  'rust': ['analyzer'],
\ 'python': ['ruff'],
\}

let g:ale_fixers = { 'rust': ['rustfmt', 'trim_whitespace', 'remove_trailing_lines'],
            \ 'python': ['ruff', 'ruff_format'],
            \ '*': ['remove_trailing_lines', 'trim_whitespace'],
            \}

" Format when the file is saved (:w)
let g:ale_python_ruff_options = '--extend-select I'

" Ruff
let g:vimruff_default = "both"
let g:ale_completion_enabled = 1
let g:ale_fix_on_save = 1
let g:ale_lint_on_text_changed = 'never'
let g:ale_lint_on_enter = 0
```