### PR TITLE
[RI] Change the fuzz factor to 2

### DIFF
--- a/run_interdiff.py
+++ b/run_interdiff.py
@@ -89,7 +89,7 @@ def run_interdiff(repo, backport_sha, upstream_sha, interdiff_path):
             up_path = up.name
 
         interdiff_result = subprocess.run(
-            [interdiff_path, "--fuzzy=3", bp_path, up_path], text=True, capture_output=True, check=False
+            [interdiff_path, "--fuzzy", bp_path, up_path], text=True, capture_output=True, check=False
         )
 
         # Check for interdiff errors (non-zero return code other than 1)


### PR DESCRIPTION
When a fuzz factor of 3 results in an incorrect patch application, the final interdiff output is harder to review than when the fuzz factor is 2. This is especially the case because it's common for rejected hunks from both files to appear back-to-back, making the rejected hunks easy to review.

Turn down the fuzz factor to the default of 2 to avoid results that are very confusing.