### PR TITLE
[RR] Do not add signoff when cherry picking commits

### DIFF
--- a/rolling-release-update.py
+++ b/rolling-release-update.py
@@ -398,7 +398,7 @@ if __name__ == "__main__":
         commit_info = repo.git.show("--pretty=%h %s", "-s", ciq_commit)
         print(f"  [{commits_applied}/{len(rolling_commit_map)}] {commit_info}")
         result = subprocess.run(
-            ["git", "cherry-pick", "-s", ciq_commit], stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=args.repo
+            ["git", "cherry-pick", ciq_commit], stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=args.repo
         )
         if result.returncode != 0:
             print(f"[rolling release update] ERROR: Failed to cherry-pick commit {ciq_commit}")


### PR DESCRIPTION
During "rebase", the ciq commits are cherry picked one by one from the branch that contains the previous version of kernel. Since they are already signed off, there's no need to add another signoff. Moreover, this ends up appending signoffs every time a new rolling release update is done, polutting the commit message.