### PR TITLE
KT: changes needed for cve_remediation automation in github action

### DIFF
--- a/kt/commands/list_kernels/command.py
+++ b/kt/commands/list_kernels/command.py
@@ -4,15 +4,31 @@ from kt.commands.list_kernels.impl import main
 
 epilog = """
 It list all the kernels we currently maintain.
+If --automated or -a is used, it will list all the kernels we maintain
+but are also part of KernelCI.
 
 Example:
 
 \b
 $ kt list-kernels
+cbr-7.9
+fipslegacy-8.6
+lts-8.6
+lts-9.2
+lts-9.4
+lts-9.6
+
+\b
+$ kt list-kernels --automated
+lts-8.6
+lts-9.2
+lts-9.4
+lts-9.6
 
 """
 
 
 @click.command(epilog=epilog)
-def list_kernels():
-    main()
+@click.option("-a", "--automated", is_flag=True, help="It selects only automated kernels")
+def list_kernels(automated):
+    main(automated)

--- a/kt/commands/list_kernels/impl.py
+++ b/kt/commands/list_kernels/impl.py
@@ -2,8 +2,10 @@ from kt.ktlib.config import Config
 from kt.ktlib.kernels import KernelsInfo
 
 
-def main():
+def main(automated: bool = False):
     config = Config.load()
     kernels = KernelsInfo.from_yaml(config=config).kernels
-    for k in sorted(kernels):
-        print(k)
+
+    for k in sorted(kernels.values(), key=lambda k: k.name):
+        if not automated or k.automated:
+            print(k.name)

--- a/kt/data/kernels.yaml
+++ b/kt/data/kernels.yaml
@@ -44,10 +44,3 @@ kernels:
     dist_git_root: dist-git-tree-fips
     dist_git_branch: fips-compliant8
     mock_config: rocky-lts86-fips
-
-  fips-9.2:
-    src_tree_root: kernel-src-tree
-    src_tree_branch: fips-9-compliant/5.14.0-284.30.1
-    dist_git_root: dist-git-tree-fips
-    dist_git_branch: el92-fips-compliant-9
-    mock_config: rocky-fips92

--- a/kt/data/kernels.yaml
+++ b/kt/data/kernels.yaml
@@ -9,6 +9,7 @@ kernels:
     dist_git_root: dist-git-tree-cbr
     dist_git_branch: cbr79-7
     mock_config: centos-cbr79
+    automated: false
 
   lts-8.6:
     src_tree_root: kernel-src-tree
@@ -16,6 +17,7 @@ kernels:
     dist_git_root: dist-git-tree-lts
     dist_git_branch: lts86-8
     mock_config: rocky-lts86
+    automated: true
 
   lts-9.2:
     src_tree_root: kernel-src-tree
@@ -23,6 +25,7 @@ kernels:
     dist_git_root: dist-git-tree-lts
     dist_git_branch: lts92-9
     mock_config: rocky-lts92
+    automated: true
 
   lts-9.4:
     src_tree_root: kernel-src-tree
@@ -30,6 +33,7 @@ kernels:
     dist_git_root: dist-git-tree-lts
     dist_git_branch: lts94-9
     mock_config: rocky-lts94
+    automated: true
 
   lts-9.6:
     src_tree_root: kernel-src-tree
@@ -37,6 +41,7 @@ kernels:
     dist_git_root: dist-git-tree-lts
     dist_git_branch: lts96-9
     mock_config: rocky-lts96
+    automated: true
 
   fipslegacy-8.6:
     src_tree_root: kernel-src-tree
@@ -44,3 +49,4 @@ kernels:
     dist_git_root: dist-git-tree-fips
     dist_git_branch: fips-compliant8
     mock_config: rocky-lts86-fips
+    automated: false

--- a/kt/ktlib/config.py
+++ b/kt/ktlib/config.py
@@ -32,6 +32,7 @@ class Config:
     images_dir: Path
 
     ssh_key: Path
+    user: str
 
     DEFAULT: ClassVar = {
         "base_path": "~/ciq",
@@ -39,14 +40,15 @@ class Config:
         "images_source_dir": "~/ciq/default_test_images",
         "images_dir": "~/ciq/tmp/virt-images",
         "ssh_key": "~/.ssh/id_ed25519_generic.pub",
+        "user": os.environ["USER"],
     }
 
     @classmethod
     def from_str_dict(cls, data: dict[str, str]):
-        # Transform the str values to Path
-        new_data = {k: Path(v).expanduser() for k, v in data.items()}
-
-        if not all(v.is_absolute() for v in new_data.values()):
+        # Transform the str values to Path except for user
+        non_path_keys = {"user"}
+        new_data = {k: (Path(v).expanduser() if k not in non_path_keys else v) for k, v in data.items()}
+        if not all(v.is_absolute() for k, v in new_data.items() if k not in non_path_keys):
             raise ValueError("all paths should be absolute; check your config")
 
         return cls(**new_data)

--- a/kt/ktlib/kernel_workspace.py
+++ b/kt/ktlib/kernel_workspace.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from dataclasses import dataclass
 
 from git import GitCommandError, Repo
@@ -171,7 +170,7 @@ class KernelWorkspace:
             name = name + "_" + extra
 
         folder = config.kernels_dir / Path(name)
-        user = os.environ["USER"]
+        user = config.user
         default_remote = "origin"
 
         dist_folder = folder / Path(Constants.DIST_TREE)

--- a/kt/ktlib/kernels.py
+++ b/kt/ktlib/kernels.py
@@ -37,6 +37,8 @@ class KernelInfo:
 
     mock_config: str
 
+    automated: bool
+
 
 @dataclass
 class KernelsInfo:

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -138,10 +138,10 @@ class Vm:
             data = yaml.safe_load(f)
 
         # replace placeholders with user data
-        data["users"][0]["name"] = os.environ["USER"]
+        data["users"][0]["name"] = config.user
 
         # password remains the default for now
-        data["chpasswd"]["list"][0] = f"{os.environ['USER']}:test"
+        data["chpasswd"]["list"][0] = f"{config.user}:test"
 
         # ssh key
         with open(config.ssh_key) as f:
@@ -157,8 +157,8 @@ class Vm:
 
         # Because $HOME is the same as the host, during boot, cloud-init
         # sees the home dir already exists and root remains the owner
-        # change it to $USER
-        data["runcmd"][0][1] = f"{os.environ['USER']}:{os.environ['USER']}"
+        # change it to {config.user}
+        data["runcmd"][0][1] = f"{config.user}:{config.user}"
         data["runcmd"][0][2] = os.environ["HOME"]
 
         # Install packages needed later

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,6 @@ py-modules = []
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["kt*"]
+
+[tool.setuptools.package-data]
+"kt" = ["data/*.yaml"]


### PR DESCRIPTION
It started from needing a way to list the kernels we support.
```
kt list-kernels
```
but cbr7.9 and fipslegacy are not fully automated.
This is how I came up with an extra flag automated.

For cve remediation automation, the `user` will be `ciq_kernel_automation`.
And not the system one. To make it possible, user is now configurable. By default it will be taken from env var USER.
  
Last thing  required to use kt in a github action was to make sure the files under ktlib/data are accessible when kt is installed as a package.
 