### PR TITLE
A few kt VM tweaks

### DIFF
--- a/kt/commands/content_release/impl.py
+++ b/kt/commands/content_release/impl.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import time
 
 from git import GitCommandError, Repo
 
@@ -10,7 +9,6 @@ from kt.ktlib.kernel_workspace import KernelWorkspace
 from kt.ktlib.local import LocalCommand
 from kt.ktlib.mock import Mock
 from kt.ktlib.ssh import SshCommand
-from kt.ktlib.util import Constants
 from kt.ktlib.vm import Vm
 
 # Source download configuration for kernels that don't work with getsrc.sh
@@ -309,7 +307,7 @@ class ContentRelease:
 
         # Wait for dependencies to be installed if VM was just created
         logging.info("Waiting for VM dependencies to be installed...")
-        time.sleep(Constants.VM_DEPS_INSTALL_WAIT_SECONDS)
+        SshCommand.run(domain=vm_instance.domain, command=["sudo cloud-init status --wait || true"])
 
         # Install the built RPMs
         build_files_dir = kernel_workspace_obj.folder / "build_files"

--- a/kt/commands/vm/command.py
+++ b/kt/commands/vm/command.py
@@ -58,8 +58,9 @@ $ kt vm lts9_4 -c --override
 )
 @click.option("--test", is_flag=True, help="Build the kernel and run kselftests")
 @click.option("--vcpus", type=int, default=12, help="Number of virtual CPUs (default: 12)")
+@click.option("--memory", type=int, default=32768, help="Memory in MiB (default: 32768)")
 @click.argument("kernel_workspace", required=False, shell_complete=ShellCompletion.show_kernel_workspaces)
-def vm(kernel_workspace, console, destroy, override, list_all, test, vcpus):
+def vm(kernel_workspace, console, destroy, override, list_all, test, vcpus, memory):
     if not list_all and not kernel_workspace:
         raise click.UsageError("kernel_workspace is required unless --list-all is specified")
 
@@ -71,4 +72,5 @@ def vm(kernel_workspace, console, destroy, override, list_all, test, vcpus):
         list_all=list_all,
         test=test,
         vcpus=vcpus,
+        memory=memory,
     )

--- a/kt/commands/vm/command.py
+++ b/kt/commands/vm/command.py
@@ -57,9 +57,18 @@ $ kt vm lts9_4 -c --override
     help="Lists existings vms",
 )
 @click.option("--test", is_flag=True, help="Build the kernel and run kselftests")
+@click.option("--vcpus", type=int, default=12, help="Number of virtual CPUs (default: 12)")
 @click.argument("kernel_workspace", required=False, shell_complete=ShellCompletion.show_kernel_workspaces)
-def vm(kernel_workspace, console, destroy, override, list_all, test):
+def vm(kernel_workspace, console, destroy, override, list_all, test, vcpus):
     if not list_all and not kernel_workspace:
         raise click.UsageError("kernel_workspace is required unless --list-all is specified")
 
-    main(name=kernel_workspace, console=console, destroy=destroy, override=override, list_all=list_all, test=test)
+    main(
+        name=kernel_workspace,
+        console=console,
+        destroy=destroy,
+        override=override,
+        list_all=list_all,
+        test=test,
+        vcpus=vcpus,
+    )

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -6,7 +6,7 @@ from kt.ktlib.virt import VmCommand
 from kt.ktlib.vm import Vm
 
 
-def main(name: str, console: bool, destroy: bool, override: bool, list_all: bool, test: bool = False):
+def main(name: str, console: bool, destroy: bool, override: bool, list_all: bool, test: bool = False, vcpus: int = 12):
     if list_all:
         VmCommand.list_all()
         return
@@ -20,7 +20,7 @@ def main(name: str, console: bool, destroy: bool, override: bool, list_all: bool
         vm.destroy()
         return
 
-    vm_instance = Vm.setup_and_spinup(kernel_workspace_name=name, override=override)
+    vm_instance = Vm.setup_and_spinup(kernel_workspace_name=name, override=override, vcpus=vcpus)
     config = Config.load()
 
     if test:

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -1,8 +1,7 @@
 import logging
-import time
 
 from kt.ktlib.config import Config
-from kt.ktlib.util import Constants
+from kt.ktlib.ssh import SshCommand
 from kt.ktlib.virt import VmCommand
 from kt.ktlib.vm import Vm
 
@@ -25,9 +24,8 @@ def main(name: str, console: bool, destroy: bool, override: bool, list_all: bool
     config = Config.load()
 
     if test:
-        # Wait for the dependencies to be installed
-        logging.info("Waiting for the deps to be installed")
-        time.sleep(Constants.VM_DEPS_INSTALL_WAIT_SECONDS)
+        logging.info("Waiting for cloud-init to finish...")
+        SshCommand.run(domain=vm_instance.domain, command=["sudo cloud-init status --wait || true"])
         vm_instance.test(config=config)
 
     if console:

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -6,7 +6,16 @@ from kt.ktlib.virt import VmCommand
 from kt.ktlib.vm import Vm
 
 
-def main(name: str, console: bool, destroy: bool, override: bool, list_all: bool, test: bool = False, vcpus: int = 12):
+def main(
+    name: str,
+    console: bool,
+    destroy: bool,
+    override: bool,
+    list_all: bool,
+    test: bool = False,
+    vcpus: int = 12,
+    memory: int = 32768,
+):
     if list_all:
         VmCommand.list_all()
         return
@@ -20,7 +29,7 @@ def main(name: str, console: bool, destroy: bool, override: bool, list_all: bool
         vm.destroy()
         return
 
-    vm_instance = Vm.setup_and_spinup(kernel_workspace_name=name, override=override, vcpus=vcpus)
+    vm_instance = Vm.setup_and_spinup(kernel_workspace_name=name, override=override, vcpus=vcpus, memory=memory)
     config = Config.load()
 
     if test:

--- a/kt/ktlib/util.py
+++ b/kt/ktlib/util.py
@@ -13,6 +13,5 @@ class Constants:
 
     CLOUD_INIT = "cloud_init.yaml"
 
-    VM_DEPS_INSTALL_WAIT_SECONDS = 300
     VM_STARTUP_WAIT_SECONDS = 60
     VM_REBOOT_WAIT_SECONDS = 120

--- a/kt/ktlib/virt.py
+++ b/kt/ktlib/virt.py
@@ -42,6 +42,7 @@ class VmCommand(CommandRunner):
         cloud_init_path: Path,
         common_dir: Path,
         vcpus: int = 12,
+        memory: int = 32768,
     ):
         command = [
             "--name",
@@ -54,7 +55,7 @@ class VmCommand(CommandRunner):
             "--vcpus",
             str(vcpus),
             "--memory",
-            str(32768),
+            str(memory),
             "--vnc",
             "--cloud-init",
             f"user-data={cloud_init_path}",

--- a/kt/ktlib/virt.py
+++ b/kt/ktlib/virt.py
@@ -41,6 +41,7 @@ class VmCommand(CommandRunner):
         vm_major_version: str,
         cloud_init_path: Path,
         common_dir: Path,
+        vcpus: int = 12,
     ):
         command = [
             "--name",
@@ -51,7 +52,7 @@ class VmCommand(CommandRunner):
             "--virt-type",
             "kvm",
             "--vcpus",
-            "12,vcpu.cpuset=0-11,vcpu.placement=static",
+            str(vcpus),
             "--memory",
             str(32768),
             "--vnc",

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -96,7 +96,7 @@ class Vm:
         return cls.load(config=config, kernel_workspace=kernel_workspace)
 
     @classmethod
-    def setup_and_spinup(cls, kernel_workspace_name: str, override: bool = False, vcpus: int = 12):
+    def setup_and_spinup(cls, kernel_workspace_name: str, override: bool = False, vcpus: int = 12, memory: int = 32768):
         """
         Setup and spin up a VM from a kernel workspace name.
 
@@ -104,6 +104,7 @@ class Vm:
             kernel_workspace_name: The name of the kernel workspace
             override: If True, destroy and recreate the VM
             vcpus: Number of virtual CPUs
+            memory: Memory in MiB
 
         Returns:
             VmInstance: The running VM instance
@@ -115,7 +116,7 @@ class Vm:
             vm.destroy()
 
         vm.setup(config=config)
-        vm_instance = vm.spin_up(config=config, vcpus=vcpus)
+        vm_instance = vm.spin_up(config=config, vcpus=vcpus, memory=memory)
 
         return vm_instance
 
@@ -169,7 +170,7 @@ class Vm:
             f.write("#cloud-config\n")
             yaml.dump(data, f)
 
-    def _create_image(self, config: Config, vcpus: int = 12):
+    def _create_image(self, config: Config, vcpus: int = 12, memory: int = 32768):
         # Make sure the dir exists
         self.qcow2_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -180,10 +181,10 @@ class Vm:
         # Resize the disk to 30GB
         self._resize_disk()
 
-        self._virt_install(config=config, vcpus=vcpus)
+        self._virt_install(config=config, vcpus=vcpus, memory=memory)
         time.sleep(Constants.VM_STARTUP_WAIT_SECONDS)
 
-    def _virt_install(self, config: Config, vcpus: int = 12):
+    def _virt_install(self, config: Config, vcpus: int = 12, memory: int = 32768):
         return VmCommand.install(
             name=self.name,
             qcow2_path=self.qcow2_path,
@@ -191,6 +192,7 @@ class Vm:
             cloud_init_path=self.cloud_init_path,
             common_dir=config.base_path,
             vcpus=vcpus,
+            memory=memory,
         )
 
     def _resize_disk(self):
@@ -204,11 +206,11 @@ class Vm:
     def setup(self, config: Config):
         self._download_source_image()
 
-    def spin_up(self, config: Config, vcpus: int = 12) -> VmInstance:
+    def spin_up(self, config: Config, vcpus: int = 12, memory: int = 32768) -> VmInstance:
         if not VirtHelper.exists(vm_name=self.name):
             logging.info(f"VM {self.name} does not exist, creating from scratch...")
 
-            self._create_image(config=config, vcpus=vcpus)
+            self._create_image(config=config, vcpus=vcpus, memory=memory)
             return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace)
 
         logging.info(f"Vm {self.name} already exists")

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -96,13 +96,14 @@ class Vm:
         return cls.load(config=config, kernel_workspace=kernel_workspace)
 
     @classmethod
-    def setup_and_spinup(cls, kernel_workspace_name: str, override: bool = False):
+    def setup_and_spinup(cls, kernel_workspace_name: str, override: bool = False, vcpus: int = 12):
         """
         Setup and spin up a VM from a kernel workspace name.
 
         Args:
             kernel_workspace_name: The name of the kernel workspace
             override: If True, destroy and recreate the VM
+            vcpus: Number of virtual CPUs
 
         Returns:
             VmInstance: The running VM instance
@@ -114,7 +115,7 @@ class Vm:
             vm.destroy()
 
         vm.setup(config=config)
-        vm_instance = vm.spin_up(config=config)
+        vm_instance = vm.spin_up(config=config, vcpus=vcpus)
 
         return vm_instance
 
@@ -168,7 +169,7 @@ class Vm:
             f.write("#cloud-config\n")
             yaml.dump(data, f)
 
-    def _create_image(self, config: Config):
+    def _create_image(self, config: Config, vcpus: int = 12):
         # Make sure the dir exists
         self.qcow2_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -179,16 +180,17 @@ class Vm:
         # Resize the disk to 30GB
         self._resize_disk()
 
-        self._virt_install(config=config)
+        self._virt_install(config=config, vcpus=vcpus)
         time.sleep(Constants.VM_STARTUP_WAIT_SECONDS)
 
-    def _virt_install(self, config: Config):
+    def _virt_install(self, config: Config, vcpus: int = 12):
         return VmCommand.install(
             name=self.name,
             qcow2_path=self.qcow2_path,
             vm_major_version=self.vm_major_version,
             cloud_init_path=self.cloud_init_path,
             common_dir=config.base_path,
+            vcpus=vcpus,
         )
 
     def _resize_disk(self):
@@ -202,11 +204,11 @@ class Vm:
     def setup(self, config: Config):
         self._download_source_image()
 
-    def spin_up(self, config: Config) -> VmInstance:
+    def spin_up(self, config: Config, vcpus: int = 12) -> VmInstance:
         if not VirtHelper.exists(vm_name=self.name):
             logging.info(f"VM {self.name} does not exist, creating from scratch...")
 
-            self._create_image(config=config)
+            self._create_image(config=config, vcpus=vcpus)
             return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace)
 
         logging.info(f"Vm {self.name} already exists")


### PR DESCRIPTION
These came to light as I've been working on getting a kt based content release workflow running on jenkins.

* Using the 'cloud-init status --wait' ensures all the dependency installs are actually done before continuing.
* In the case of a content release the vm isn't building anything, just running kselftests, and using up all those cpus and ram seems like overkill
* This also removes `,vcpu.cpuset=0-11,vcpu.placement=static` from the vcpu config as that seems very host specific for a general use tool like this.