### PR TITLE
kt/data/kernels.yaml: Add kernel-src-tree-tools repo

### DIFF
--- a/kt/commands/setup/impl.py
+++ b/kt/commands/setup/impl.py
@@ -1,5 +1,8 @@
+import logging
+
 from kt.ktlib.config import Config
 from kt.ktlib.kernels import KernelsInfo
+from kt.ktlib.repo import RepoInfoException
 
 
 def main():
@@ -10,4 +13,7 @@ def main():
 
     repos = KernelsInfo.from_yaml(config=config).repos
     for repo in repos.values():
-        repo.setup_repo()
+        try:
+            repo.setup_repo()
+        except RepoInfoException as e:
+            logging.error(e, exc_info=True)

--- a/kt/data/kernels.yaml
+++ b/kt/data/kernels.yaml
@@ -1,6 +1,7 @@
 common_repos:
   dist-git-tree-fips: git@gitlab.com:ctrl-iq-public/fips/src/kernel.git
   kernel-src-tree: https://github.com/ctrliq/kernel-src-tree.git
+  kernel-src-tree-tools: https://github.com/ctrliq/kernel-src-tree-tools.git
 
 kernels:
   cbr-7.9:

--- a/kt/ktlib/repo.py
+++ b/kt/ktlib/repo.py
@@ -37,8 +37,7 @@ class RepoInfo:
     def setup_repo(self):
         """
         Set up a git repository at the destination.
-        If destination already exists and override == True,
-        nothing is done
+        If destination already exists, update it.
         """
 
         if not self.folder.exists():

--- a/kt/ktlib/repo.py
+++ b/kt/ktlib/repo.py
@@ -6,6 +6,10 @@ from git import Repo
 from pathlib3x import Path
 
 
+class RepoInfoException(Exception):
+    pass
+
+
 @dataclass
 class RepoInfo:
     """
@@ -36,9 +40,17 @@ class RepoInfo:
         If destination already exists and override == True,
         nothing is done
         """
+
         if not self.folder.exists():
-            self._clone_repo()
+            try:
+                self._clone_repo()
+            except git.GitCommandError as e:
+                raise RepoInfoException(f"{self.folder.name} could not be cloned") from e
+
             return
 
         logging.info(f"{self.folder} already exists, updating it")
-        self._update()
+        try:
+            self._update()
+        except git.GitCommandError as e:
+            raise RepoInfoException(f"{self.folder.name} could not be updated") from e


### PR DESCRIPTION
kt/data/kernels.yaml: Add kernel-src-tree-tools repo

So that it will be cloned/updated during kt setup. Because users will probably have local unstaged changes, the current git pull --rebase will fail. The error is caught but kt setup will continue to clone/update the rest of the repos.

While at it, update dostring for setup_repo that was not up to date. 