### PR TITLE
kt vm: use different qcow images

### DIFF
--- a/kt/KT.md
+++ b/kt/KT.md
@@ -261,10 +261,10 @@ For this configuration
 }
 ```
 
-Here is the qcow2 vm image used as source for other vms as well:
+Here is the qcow2 vm image used as source for other vms for 9.4 kernels as well:
 
 ```
-~/ciq/default_test_images/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2
+~/ciq/default_test_images/Rocky-9.4-GenericCloud.latest.x86_64.qcow2
 ```
 
 And here are the actual vm configuration and image files:

--- a/kt/KT.md
+++ b/kt/KT.md
@@ -197,7 +197,7 @@ before creating it from scratch again.
 
 #### Example:
 ```
-$ kt checkout lts9_4
+$ kt checkout lts-9.4
 ```
 
 For this configuration
@@ -212,7 +212,7 @@ For this configuration
 ```
 
 This is the working directory for this kernel:
-`~/ciq/kernels/lts9_4`.
+`~/ciq/kernels/lts-9.4`.
 
 2 git worktrees are created:
 
@@ -247,7 +247,7 @@ $ sudo usermod -a -G libvirt $(whoami)
 
 #### Example:
 ```
-$ kt vm lts9_4
+$ kt vm lts-9.4
 ```
 
 For this configuration

--- a/kt/commands/checkout/command.py
+++ b/kt/commands/checkout/command.py
@@ -25,16 +25,16 @@ The local branch is {<user>}/<branch>.
 Examples:
 
 \b
-$ kt checkout lts9_4
+$ kt checkout lts-9.4
 \b
-$ kt checkout lts9_4 --cleanup
+$ kt checkout lts-9.4 --cleanup
 \b
-$ kt checkout lts9_4 --cleanup -c
+$ kt checkout lts-9.4 --cleanup -c
 \b
-$ kt checkout lts9_4 --cleanup --change-dir
+$ kt checkout lts-9.4 --cleanup --change-dir
 \b
-$ kt checkout lts9_4 -e CVE-2022-49909
-Will create folder lts9_4_CVE-2022-49909 instead of lts9_4.
+$ kt checkout lts-9.4 -e CVE-2022-49909
+Will create folder lts-9.4_CVE-2022-49909 instead of lts-9.4.
 """
 
 

--- a/kt/commands/git_push/command.py
+++ b/kt/commands/git_push/command.py
@@ -15,17 +15,17 @@ This command will push this branch to the origin.
 Examples:
 
 \b
-$ kt git-push lts9_4 -k
-Will push the branch {USER}_ciqlts9_4 from kernel-src-tree from lts9_4 kernel
+$ kt git-push lts-9.4 -k
+Will push the branch {USER}_ciqlts-9.4 from kernel-src-tree from lts-9.4 kernel
 workspace.
 
 \b
-$ kt git-push lts9_4 -k -f
+$ kt git-push lts-9.4 -k -f
 Same as above but it will force push
 
 \b
-$ kt git-push lts9_4 -d
-Will push the branch {USER}_lts94-9 from kernel-dist-tree from lts9_4 kernel
+$ kt git-push lts-9.4 -d
+Will push the branch {USER}_lts94-9 from kernel-dist-tree from lts-9.4 kernel
 workspace.
 
 """

--- a/kt/commands/vm/command.py
+++ b/kt/commands/vm/command.py
@@ -17,6 +17,12 @@ they will have their own configuration and image.
 cloud-init.yaml configuration is taken from kt/data and modified accordingly
 for each user and then put in the same folder.
 
+If the base image exists at <config.images_source_dir>, it will be reused
+forever, unless parameter --override-base is used to download the
+base image and replace it. Note, this won't interfere with existing
+vms that share the same base because their own image is copied in their
+own <config.images_dir>/<kernel> folder.
+
 Examples:
 
 \b
@@ -29,7 +35,8 @@ $ kt vm lts9_4 -c
 $ kt vm lts9_4 --destroy
 \b
 $ kt vm lts9_4 -c --override
-
+\b
+$ kt vm lts9_4 -c --override-base
 """
 
 
@@ -52,6 +59,11 @@ $ kt vm lts9_4 -c --override
     help="It destroys the vm if it exists and creates a new one",
 )
 @click.option(
+    "--override-base",
+    is_flag=True,
+    help="It destroys the vm if it exists and creates a new one, but it will also override the base qcow image",
+)
+@click.option(
     "--list-all",
     is_flag=True,
     help="Lists existings vms",
@@ -60,7 +72,7 @@ $ kt vm lts9_4 -c --override
 @click.option("--vcpus", type=int, default=12, help="Number of virtual CPUs (default: 12)")
 @click.option("--memory", type=int, default=32768, help="Memory in MiB (default: 32768)")
 @click.argument("kernel_workspace", required=False, shell_complete=ShellCompletion.show_kernel_workspaces)
-def vm(kernel_workspace, console, destroy, override, list_all, test, vcpus, memory):
+def vm(kernel_workspace, console, destroy, override, override_base, list_all, test, vcpus, memory):
     if not list_all and not kernel_workspace:
         raise click.UsageError("kernel_workspace is required unless --list-all is specified")
 
@@ -69,6 +81,7 @@ def vm(kernel_workspace, console, destroy, override, list_all, test, vcpus, memo
         console=console,
         destroy=destroy,
         override=override,
+        override_base=override_base,
         list_all=list_all,
         test=test,
         vcpus=vcpus,

--- a/kt/commands/vm/command.py
+++ b/kt/commands/vm/command.py
@@ -26,17 +26,17 @@ own <config.images_dir>/<kernel> folder.
 Examples:
 
 \b
-$ kt vm lts9_4
+$ kt vm lts-9.4
 \b
-$ kt vm lts9_4 --console
+$ kt vm lts-9.4 --console
 \b
-$ kt vm lts9_4 -c
+$ kt vm lts-9.4 -c
 \b
-$ kt vm lts9_4 --destroy
+$ kt vm lts-9.4 --destroy
 \b
-$ kt vm lts9_4 -c --override
+$ kt vm lts-9.4 -c --override
 \b
-$ kt vm lts9_4 -c --override-base
+$ kt vm lts-9.4 -c --override-base
 """
 
 

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -11,6 +11,7 @@ def main(
     console: bool,
     destroy: bool,
     override: bool,
+    override_base: bool,
     list_all: bool,
     test: bool = False,
     vcpus: int = 12,
@@ -29,7 +30,9 @@ def main(
         vm.destroy()
         return
 
-    vm_instance = Vm.setup_and_spinup(kernel_workspace_name=name, override=override, vcpus=vcpus, memory=memory)
+    vm_instance = Vm.setup_and_spinup(
+        kernel_workspace_name=name, override=override, override_base=override_base, vcpus=vcpus, memory=memory
+    )
     config = Config.load()
 
     if test:

--- a/kt/ktlib/util.py
+++ b/kt/ktlib/util.py
@@ -7,8 +7,8 @@ class Constants:
     COMMON_REPOS = "common_repos"
     KERNELS = "kernels"
 
-    BASE_URL = "https://download.rockylinux.org/pub/rocky"
-    QCOW2_TRAIL = "GenericCloud-Base.latest.x86_64.qcow2"
+    BASE_URL = "https://dl.rockylinux.org/vault/rocky"
+    QCOW2_TRAIL = "GenericCloud.latest.x86_64.qcow2"
     DEFAULT_VM_BASE = "Rocky"
 
     CLOUD_INIT = "cloud_init.yaml"

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -31,12 +31,14 @@ class Vm:
 
     qcow2_source_path: qcow2 path to the vm image used as source
     vm_major_version: major vm version (9 for Rocky 9)
+    vm_major_version: major.minor vm version (9.2 for Rocky 9.2)
     qcow2_path: the qcow2 path of the vm image copied from qcow2_source_path
     cloud_init_path: cloud_init.yaml config, adapted from data/cloud_init.yaml
     """
 
     qcow2_source_path: Path
     vm_major_version: str
+    vm_major_minor_version: str
     qcow2_path: Path
     cloud_init_path: Path
     name: str
@@ -47,9 +49,12 @@ class Vm:
         kernel_workspace_str = kernel_workspace.folder.name
         kernel_name = cls._extract_kernel_name(kernel_workspace_str)
         vm_major_version = cls._extract_major(kernel_name)
+        vm_major_minor_version = cls._extract_major_minor(kernel_name)
 
         # Image source paths construction
-        qcow2_source_path = config.images_source_dir / Path(cls._qcow2_name(vm_major_version=vm_major_version))
+        qcow2_source_path = config.images_source_dir / Path(
+            cls._qcow2_name(vm_major_minor_version=vm_major_minor_version)
+        )
 
         # Actual current image paths construction
         work_dir = config.images_dir / Path(kernel_workspace_str)
@@ -59,6 +64,7 @@ class Vm:
         return cls(
             qcow2_source_path=qcow2_source_path,
             vm_major_version=vm_major_version,
+            vm_major_minor_version=vm_major_minor_version,
             qcow2_path=qcow2_path,
             cloud_init_path=cloud_init_path,
             name=kernel_workspace_str,
@@ -76,8 +82,13 @@ class Vm:
         return full_version.split("-")[-1].split(".")[0]
 
     @classmethod
-    def _qcow2_name(cls, vm_major_version: str):
-        return f"{Constants.DEFAULT_VM_BASE}-{vm_major_version}-{Constants.QCOW2_TRAIL}"
+    def _extract_major_minor(cls, full_version):
+        # lts-9.4 -> return 9.4
+        return full_version.split("-")[-1]
+
+    @classmethod
+    def _qcow2_name(cls, vm_major_minor_version: str):
+        return f"{Constants.DEFAULT_VM_BASE}-{vm_major_minor_version}-{Constants.QCOW2_TRAIL}"
 
     @classmethod
     def load_from_workspace(cls, kernel_workspace_name: str):
@@ -121,7 +132,7 @@ class Vm:
         return vm_instance
 
     def _get_vm_url(self):
-        return f"{Constants.BASE_URL}/{self.vm_major_version}/images/x86_64/{self.qcow2_source_path.name}"
+        return f"{Constants.BASE_URL}/{self.vm_major_minor_version}/images/x86_64/{Constants.DEFAULT_VM_BASE}-{self.vm_major_version}-{Constants.QCOW2_TRAIL}"
 
     def _download_source_image(self):
         if self.qcow2_source_path.exists():
@@ -131,8 +142,11 @@ class Vm:
         # Make sure the folder exists
         self.qcow2_source_path.parent.mkdir(parents=True, exist_ok=True)
 
-        logging.info("Downloading image")
-        wget.download(self._get_vm_url(), out=str(self.qcow2_source_path.parent))
+        # Delete existing image if it exists
+        self.qcow2_source_path.unlink(missing_ok=True)
+
+        logging.info(f"Downloading image from {self._get_vm_url()}")
+        wget.download(self._get_vm_url(), out=str(self.qcow2_source_path))
 
     def _setup_cloud_init(self, config: Config):
         data = None

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -107,13 +107,21 @@ class Vm:
         return cls.load(config=config, kernel_workspace=kernel_workspace)
 
     @classmethod
-    def setup_and_spinup(cls, kernel_workspace_name: str, override: bool = False, vcpus: int = 12, memory: int = 32768):
+    def setup_and_spinup(
+        cls,
+        kernel_workspace_name: str,
+        override: bool = False,
+        override_base: bool = False,
+        vcpus: int = 12,
+        memory: int = 32768,
+    ):
         """
         Setup and spin up a VM from a kernel workspace name.
 
         Args:
             kernel_workspace_name: The name of the kernel workspace
             override: If True, destroy and recreate the VM
+            override_base: If True, destroy and recreate the VM but override the base image as well
             vcpus: Number of virtual CPUs
             memory: Memory in MiB
 
@@ -123,10 +131,10 @@ class Vm:
         vm = cls.load_from_workspace(kernel_workspace_name)
         config = Config.load()
 
-        if override:
+        if override or override_base:
             vm.destroy()
 
-        vm.setup(config=config)
+        vm.setup(override_base=override_base)
         vm_instance = vm.spin_up(config=config, vcpus=vcpus, memory=memory)
 
         return vm_instance
@@ -134,8 +142,8 @@ class Vm:
     def _get_vm_url(self):
         return f"{Constants.BASE_URL}/{self.vm_major_minor_version}/images/x86_64/{Constants.DEFAULT_VM_BASE}-{self.vm_major_version}-{Constants.QCOW2_TRAIL}"
 
-    def _download_source_image(self):
-        if self.qcow2_source_path.exists():
+    def _download_source_image(self, override_base: bool = False):
+        if self.qcow2_source_path.exists() and not override_base:
             logging.info(f"Image {self.qcow2_source_path} already exists, nothing to do")
             return
 
@@ -217,8 +225,8 @@ class Vm:
         except RuntimeError as e:
             raise RuntimeError(f"Failed to resize disk image: {e}")
 
-    def setup(self, config: Config):
-        self._download_source_image()
+    def setup(self, override_base: bool = False):
+        self._download_source_image(override_base=override_base)
 
     def spin_up(self, config: Config, vcpus: int = 12, memory: int = 32768) -> VmInstance:
         if not VirtHelper.exists(vm_name=self.name):


### PR DESCRIPTION
https://ciqinc.atlassian.net/browse/KERNEL-904

1. Instead of reusing the same base image for all 9.x (latest 9.7 at the moment) or 8.x kernels (latest 8.10 at the moment), we now use the matching qcow images that take into account the minor version as well.
Url used
https://dl.rockylinux.org/vault/rocky/9.2/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2

2. Added --override-base that will delete the qcow base and download it again. After the vm is deleted of course. Then the vm is setup and instantiated from a fresh base. 

3. While at it, fixed a typo in some command helpers.

## Test
```
[rnicolescu@localhost lts-9.6]$ uname -r
5.14.0-570.17.1.el9_6.x86_64
```

```
[rnicolescu@localhost lts-9.4]$ uname -r
5.14.0-427.18.1.el9_4.x86_64
```

```
[rnicolescu@localhost lts-9.2]$ uname -r
5.14.0-284.11.1.el9_2.x86_64
```

```
[rnicolescu@localhost lts-8.6]$ uname -r
4.18.0-372.13.1.el8_6.x86_64
```

Base images
```
$ ~/ciq/default_test_images
$ ll
total 4.6G
-rw-r--r--. 1 rnicolescu rnicolescu 2.5G May 22 12:36 Rocky-8.6-GenericCloud.latest.x86_64.qcow2
-rw-r--r--. 1 rnicolescu rnicolescu 944M May 22 12:31 Rocky-9.2-GenericCloud.latest.x86_64.qcow2
-rw-r--r--. 1 rnicolescu rnicolescu 576M May 22 12:27 Rocky-9.4-GenericCloud.latest.x86_64.qcow2
-rw-r--r--. 1 rnicolescu rnicolescu 599M May 22 12:21 Rocky-9.6-GenericCloud.latest.x86_64.qcow2
```

## Test for --override-base
```
❯ kt vm lts-9.6 -c --override-base
INFO:Running command ['virsh', '--connect', 'qemu:///system', 'dominfo', 'lts-9.6']
INFO:Running command ['virsh', '--connect', 'qemu:///system', 'destroy', 'lts-9.6']
INFO:Running command ['virsh', '--connect', 'qemu:///system', 'dominfo', 'lts-9.6']
INFO:Running command ['virsh', '--connect', 'qemu:///system', 'undefine', 'lts-9.6']
INFO:Downloading image from https://dl.rockylinux.org/vault/rocky/9.6/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2
 91% [################################################################      ]           550M / 598M
```
Proof the base is downloaded again. 