### PR TITLE
kernel_install_dep.sh: Use VERSION_ID to differentate between major versions

### DIFF
--- a/kernel_install_dep.sh
+++ b/kernel_install_dep.sh
@@ -210,14 +210,14 @@ install_kselftest_deps_10() {
     wheel
 }
 
-case "$ROCKY_SUPPORT_PRODUCT" in
-    Rocky-Linux-10)
+case "${VERSION_ID%%.*}" in
+    10)
         install_kselftest_deps_10
         ;;
-    Rocky-Linux-9)
+    9)
         install_kselftest_deps_9
         ;;
-    Rocky-Linux-8)
+    8)
         install_kselftest_deps_8
         ;;
 esac


### PR DESCRIPTION
IMPORTANT as it breaks kt vm lts8.6 and kt content-release lts8.6.
If people use the new images introduced here https://github.com/ctrliq/kernel-src-tree-tools/pull/70

Feel free to merge this even if I am not here. 

## Description 
Now that we're using maching basic images, there is a discrepancy for rocky 8.6 images:
ROCKY_SUPPORT_PRODUCT='Rocky Linux'.
Since ROCKY_SUPPORT_PRODUCT is not the same for all versions, use VERSION_ID instead.

Tested here
https://github.com/ctrliq/kernel-src-tree-tools/pull/71