### PR TITLE
kt: Introduce kt checkout/vm for rlc kernels

### DIFF
--- a/kt/data/kernels.yaml
+++ b/kt/data/kernels.yaml
@@ -1,10 +1,12 @@
 common_repos:
   dist-git-tree-fips: git@gitlab.com:ctrl-iq-public/fips/src/kernel.git
+  dist-git-tree-rlc: git@gitlab.com:ctrl-iq-public/sig-cloud-next/next/src/kernel.git
   kernel-src-tree: https://github.com/ctrliq/kernel-src-tree.git
   kernel-src-tree-tools: https://github.com/ctrliq/kernel-src-tree-tools.git
 
 kernels:
   cbr-7.9:
+    kernel_type: lts
     src_tree_root: kernel-src-tree
     src_tree_branch: ciqcbr7_9
     dist_git_root: dist-git-tree-cbr
@@ -13,6 +15,7 @@ kernels:
     automated: true
 
   lts-8.6:
+    kernel_type: lts
     src_tree_root: kernel-src-tree
     src_tree_branch: ciqlts8_6
     dist_git_root: dist-git-tree-lts
@@ -21,6 +24,7 @@ kernels:
     automated: true
 
   lts-9.2:
+    kernel_type: lts
     src_tree_root: kernel-src-tree
     src_tree_branch: ciqlts9_2
     dist_git_root: dist-git-tree-lts
@@ -29,6 +33,7 @@ kernels:
     automated: true
 
   lts-9.6:
+    kernel_type: lts
     src_tree_root: kernel-src-tree
     src_tree_branch: ciqlts9_6
     dist_git_root: dist-git-tree-lts
@@ -37,9 +42,34 @@ kernels:
     automated: true
 
   fipslegacy-8.6:
+    kernel_type: lts
     src_tree_root: kernel-src-tree
     src_tree_branch: fips-legacy-8-compliant/4.18.0-425.13.1
     dist_git_root: dist-git-tree-fips
     dist_git_branch: fips-compliant8
     mock_config: rocky-lts86-fips
+    automated: false
+  rlc-8:
+    kernel_type: rlc
+    src_tree_root: kernel-src-tree
+    src_tree_branch: rlc-8/4.18.0-553.X.Y.el8_10
+    dist_git_root: dist-git-tree-rlc
+    dist_git_branch: next-r8
+    mock_config: rocky-8-sigcloud
+    automated: false
+  rlc-9:
+    kernel_type: rlc
+    src_tree_root: kernel-src-tree
+    src_tree_branch: rlc-9/5.14.0-611.X.Y.el9_7
+    dist_git_root: dist-git-tree-rlc
+    dist_git_branch: next-r9
+    mock_config: rocky-9-sigcloud
+    automated: false
+  rlc-10:
+    kernel_type: rlc
+    src_tree_root: kernel-src-tree
+    src_tree_branch: rlc-10/6.12.0-124.X.Y.el10_1
+    dist_git_root: dist-git-tree-rlc
+    dist_git_branch: next-r10
+    mock_config: rocky-10-sigcloud
     automated: false

--- a/kt/ktlib/kernel_workspace.py
+++ b/kt/ktlib/kernel_workspace.py
@@ -1,11 +1,12 @@
 import logging
+import re
 from dataclasses import dataclass
 
 from git import GitCommandError, Repo
 from pathlib3x import Path
 
 from kt.ktlib.config import Config
-from kt.ktlib.kernels import KernelInfo
+from kt.ktlib.kernels import KernelInfo, KernelType
 from kt.ktlib.util import Constants
 
 
@@ -16,6 +17,7 @@ class RepoWorktree:
     remote: str
     remote_branch: str
     local_branch: str
+    kernel_type: KernelType
 
     @classmethod
     def load_from_filepath(cls, folder: Path):
@@ -32,12 +34,18 @@ class RepoWorktree:
 
         local_branch = repo.active_branch.name
 
+        if KernelType.RLC in str(folder.absolute()):
+            kernel_type = KernelType.RLC
+        else:
+            kernel_type = KernelType.LTS
+
         return cls(
             source_root=source_root,
             folder=folder,
             remote=remote,
             remote_branch=remote_branch,
             local_branch=local_branch,
+            kernel_type=kernel_type,
         )
 
     def setup(self):
@@ -72,6 +80,10 @@ class RepoWorktree:
         """
         logging.info("update")
         repo = Repo(self.folder)
+        if self.kernel_type == KernelType.RLC:
+            if repo.active_branch.name != self.local_branch:
+                print(f"New RLC version from {repo.active_branch.name} to {self.local_branch}")
+                repo.git.checkout(self.local_branch)
 
         repo.remotes.origin.pull(rebase=True)
 
@@ -184,7 +196,14 @@ class KernelWorkspace:
             remote=default_remote,
             remote_branch=kernel_info.dist_git_branch,
             local_branch=dist_local_branch,
+            kernel_type=kernel_info.kernel_type,
         )
+
+        if kernel_info.kernel_type == KernelType.RLC:
+            print(f"{kernel_info.src_tree_branch}")
+            kernel_info.src_tree_branch = cls._get_newest_remote_branch(
+                folder=kernel_info.src_tree_root.folder, pattern=kernel_info.src_tree_branch
+            )
 
         src_folder = folder / Path(Constants.SRC_TREE)
         src_local_branch = f"{{{user}}}_{kernel_info.src_tree_branch}"
@@ -197,6 +216,7 @@ class KernelWorkspace:
             remote=default_remote,
             remote_branch=kernel_info.src_tree_branch,
             local_branch=src_local_branch,
+            kernel_type=kernel_info.kernel_type,
         )
 
         return cls(
@@ -204,6 +224,23 @@ class KernelWorkspace:
             dist_worktree=dist_worktree,
             src_worktree=src_worktree,
         )
+
+    def _get_newest_remote_branch(folder, pattern, remote="origin"):
+        regex = re.compile("^" + re.escape(pattern).replace("X", r"(\d+)").replace("Y", r"(\d+)") + "$")
+
+        repo = Repo(folder)
+        best = None  # (X, Y, ref_name)
+
+        for ref in repo.remote(remote).refs:
+            short = ref.name.split("/", 1)[1]  # strip "origin/"
+            m = regex.match(short)
+            if not m:
+                continue
+            x, y = int(m.group(1)), int(m.group(2))
+            if best is None or (x, y) > (best[0], best[1]):
+                best = (x, y, short)
+
+        return best[2] if best else None
 
     def setup(self):
         # Make sure the folder is created

--- a/kt/ktlib/kernels.py
+++ b/kt/ktlib/kernels.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import dataclass
+from enum import StrEnum, auto
 
 import yaml
 from pathlib3x import Path
@@ -10,6 +11,11 @@ from kt.ktlib.util import Constants
 
 # TODO move this to a separate repo
 KERNEL_INFO_YAML_PATH = Path(__file__).parent.parent.joinpath("data/kernels.yaml")
+
+
+class KernelType(StrEnum):
+    LTS = auto()
+    RLC = auto()
 
 
 @dataclass
@@ -28,6 +34,7 @@ class KernelInfo:
     """
 
     name: str
+    kernel_type: KernelType
 
     src_tree_root: RepoInfo
     src_tree_branch: str

--- a/kt/ktlib/util.py
+++ b/kt/ktlib/util.py
@@ -8,6 +8,7 @@ class Constants:
     KERNELS = "kernels"
 
     BASE_URL = "https://dl.rockylinux.org/vault/rocky"
+    BASE_URL_RLC = "https://download.rockylinux.org/pub/rocky"
     QCOW2_TRAIL = "GenericCloud.latest.x86_64.qcow2"
     DEFAULT_VM_BASE = "Rocky"
 

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -12,6 +12,7 @@ from pathlib3x import Path
 
 from kt.ktlib.config import Config
 from kt.ktlib.kernel_workspace import KernelWorkspace
+from kt.ktlib.kernels import KernelType
 from kt.ktlib.local import LocalCommand
 from kt.ktlib.ssh import SshCommand
 from kt.ktlib.util import Constants
@@ -140,7 +141,12 @@ class Vm:
         return vm_instance
 
     def _get_vm_url(self):
-        return f"{Constants.BASE_URL}/{self.vm_major_minor_version}/images/x86_64/{Constants.DEFAULT_VM_BASE}-{self.vm_major_version}-{Constants.QCOW2_TRAIL}"
+        if KernelType.RLC in self.name:
+            base_url = Constants.BASE_URL_RLC
+        else:
+            base_url = Constants.BASE_URL
+
+        return f"{base_url}/{self.vm_major_minor_version}/images/x86_64/{Constants.DEFAULT_VM_BASE}-{self.vm_major_version}-{Constants.QCOW2_TRAIL}"
 
     def _download_source_image(self, override_base: bool = False):
         if self.qcow2_source_path.exists() and not override_base:

--- a/tests/kt/ktlib/test_kernels.py
+++ b/tests/kt/ktlib/test_kernels.py
@@ -14,6 +14,7 @@ kernels = {
         "dist_git_branch": "dist-branch",
         "mock_config": "test-mock-config",
         "automated": True,
+        "kernel_type": "lts",
     }
 }
 


### PR DESCRIPTION
Similar to current implementation for the lts kernels, except for 2 changes:
1. source tree branch changes for rlc when a new version is released, hence we cannot lock a specific version in kernels.yaml file. Instead a pattern is used. And when kt checkout is used, the latest branch that matches the pattern is found and used.
2. if a new minor rocky version is released, qcow images are usually published later. Hence the url for a specific rocky linux won't work. As a temporary solution, the latest qcow image is used for a major version.
