### PR TITLE
Upstream Commit Checker.

### DIFF
--- a/check-upstream-commit.sh
+++ b/check-upstream-commit.sh
@@ -1,0 +1,363 @@
+#!/bin/bash
+#
+# check-upstream-commit.sh — Check if an upstream commit SHA is present
+# (directly or as a backport reference) across CIQ maintained kernels.
+#
+# Usage:
+#   ./scripts/check-upstream-commit.sh <sha> [sha2 ...]
+#   ./scripts/check-upstream-commit.sh -f file_of_shas.txt
+#   ./scripts/check-upstream-commit.sh --fetch <sha>
+#
+# Options:
+#   -f, --file FILE      Read SHAs from FILE (one per line, # comments ok)
+#   -F, --fetch          Run git fetch before checking
+#   -r, --remote REMOTE  Remote name (default: origin)
+#   -v, --verbose        Show matching commit subjects
+#   -q, --quiet          Only show branches where the SHA was found
+#   -j, --json           Output results as JSON
+#   -h, --help           Show this help
+#
+# Environment:
+#   KERNEL_REMOTE        Override default remote (same as --remote)
+#   KERNEL_REPO_PATH     Path to kernel-src-tree checkout
+#                        (default: auto-detect from script location)
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────
+
+REMOTE="${KERNEL_REMOTE:-origin}"
+FETCH=0
+VERBOSE=0
+QUIET=0
+JSON=0
+SHA_LIST=()
+SHA_FILE=""
+
+# ── Branch definitions ────────────────────────────────────────────────
+# Static branches (always checked as-is)
+STATIC_BRANCHES=(
+    "ciqcbr7_9"
+    "ciqlts8_6"
+    "ciqlts8_8"
+    "ciqlts9_2"
+    "ciqlts9_4"
+    "ciqlts9_6"
+    "ciq-6.12.y"
+    "ciq-6.18.y"
+)
+
+# RLC families — script auto-picks the most current branch per family
+RLC_FAMILIES=(
+    "rlc-8"
+    "rlc-9"
+    "rlc-10"
+)
+
+# ── Functions ─────────────────────────────────────────────────────────
+
+usage() {
+    sed -n '3,/^$/s/^# \?//p' "$0"
+    exit 0
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+
+resolve_repo_path() {
+    if [[ -n "${KERNEL_REPO_PATH:-}" ]]; then
+        echo "$KERNEL_REPO_PATH"
+        return
+    fi
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local repo="${script_dir%/scripts}"
+    if [[ -d "$repo/.git" || -f "$repo/.git" ]]; then
+        echo "$repo"
+        return
+    fi
+    if git rev-parse --git-dir >/dev/null 2>&1; then
+        git rev-parse --show-toplevel
+        return
+    fi
+    die "Cannot find kernel-src-tree repo. Set KERNEL_REPO_PATH or run from the repo."
+}
+
+latest_rlc_branch() {
+    local family="$1"
+    git branch -r --list "${REMOTE}/${family}/*" 2>/dev/null \
+        | sed "s|^[[:space:]]*${REMOTE}/||" \
+        | sort -t/ -k2 -V \
+        | tail -1
+}
+
+branch_label() {
+    local branch="$1"
+    case "$branch" in
+        ciqcbr7_9)    echo "CBR 7.9";;
+        ciqlts8_6)    echo "LTS 8.6";;
+        ciqlts8_8)    echo "LTS 8.8";;
+        ciqlts9_2)    echo "LTS 9.2";;
+        ciqlts9_4)    echo "LTS 9.4";;
+        ciqlts9_6)    echo "LTS 9.6";;
+        ciq-6.12.y)   echo "CLK 6.12";;
+        ciq-6.18.y)   echo "CLK 6.18";;
+        rlc-8/*)      echo "RLC 8 (${branch#rlc-8/})";;
+        rlc-9/*)      echo "RLC 9 (${branch#rlc-9/})";;
+        rlc-10/*)     echo "RLC 10 (${branch#rlc-10/})";;
+        *)            echo "$branch";;
+    esac
+}
+
+validate_sha() {
+    local sha="$1"
+    if [[ ! "$sha" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+        die "Invalid SHA: '$sha' (expected 7-40 hex characters)"
+    fi
+}
+
+# ── Argument parsing ─────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)    usage;;
+        -f|--file)    SHA_FILE="$2"; shift 2;;
+        -F|--fetch)   FETCH=1; shift;;
+        -r|--remote)  REMOTE="$2"; shift 2;;
+        -v|--verbose) VERBOSE=1; shift;;
+        -q|--quiet)   QUIET=1; shift;;
+        -j|--json)    JSON=1; shift;;
+        -*)           die "Unknown option: $1";;
+        *)            SHA_LIST+=("$1"); shift;;
+    esac
+done
+
+if [[ -n "$SHA_FILE" ]]; then
+    [[ -f "$SHA_FILE" ]] || die "File not found: $SHA_FILE"
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line// /}"
+        [[ -n "$line" ]] && SHA_LIST+=("$line")
+    done < "$SHA_FILE"
+fi
+
+[[ ${#SHA_LIST[@]} -gt 0 ]] || die "No SHA(s) provided. Run with --help for usage."
+
+for sha in "${SHA_LIST[@]}"; do
+    validate_sha "$sha"
+done
+
+# ── Setup ─────────────────────────────────────────────────────────────
+
+REPO_PATH="$(resolve_repo_path)"
+cd "$REPO_PATH"
+
+if [[ $FETCH -eq 1 ]]; then
+    echo "Fetching ${REMOTE}..." >&2
+    git fetch "$REMOTE" --prune --quiet
+fi
+
+# ── Build branch list ────────────────────────────────────────────────
+
+BRANCHES=()
+MISSING_BRANCHES=()
+
+for b in "${STATIC_BRANCHES[@]}"; do
+    if git rev-parse --verify "${REMOTE}/${b}" >/dev/null 2>&1; then
+        BRANCHES+=("$b")
+    else
+        MISSING_BRANCHES+=("$b")
+    fi
+done
+
+for family in "${RLC_FAMILIES[@]}"; do
+    latest="$(latest_rlc_branch "$family")"
+    if [[ -n "$latest" ]]; then
+        BRANCHES+=("$latest")
+    else
+        MISSING_BRANCHES+=("$family/*")
+    fi
+done
+
+if [[ ${#MISSING_BRANCHES[@]} -gt 0 && $QUIET -eq 0 && $JSON -eq 0 ]]; then
+    echo "warning: branches not found on ${REMOTE}: ${MISSING_BRANCHES[*]}" >&2
+fi
+
+# ── Build ref list for batch operations ──────────────────────────────
+
+REFS=()
+for branch in "${BRANCHES[@]}"; do
+    REFS+=("${REMOTE}/${branch}")
+done
+
+# ── Phase 1: batch grep — single git-log pass per SHA ────────────────
+# Instead of running git-log per branch, we run ONE git-log --all --grep
+# and then figure out which branches contain each matching commit.
+# This is dramatically faster because git only walks the commit graph once.
+
+declare -A GREP_HITS          # GREP_HITS["sha:branch"] = "commit_sha subject"
+declare -A GREP_HIT_COUNTS   # GREP_HIT_COUNTS["sha:branch"] = count
+
+for sha in "${SHA_LIST[@]}"; do
+    sha_lower="$(echo "$sha" | tr '[:upper:]' '[:lower:]')"
+
+    # Get all commits across all branches that mention this SHA in their message.
+    # Use --format to get both the commit hash and subject for verbose mode.
+    matching_commits=()
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && matching_commits+=("$line")
+    done < <(git log --format="%H %s" --grep="$sha_lower" "${REFS[@]}" 2>/dev/null | sort -u)
+
+    if [[ ${#matching_commits[@]} -eq 0 ]]; then
+        continue
+    fi
+
+    # For each matching commit, determine which of our branches contain it
+    for entry in "${matching_commits[@]}"; do
+        commit_hash="${entry%% *}"
+        for i in "${!BRANCHES[@]}"; do
+            ref="${REFS[$i]}"
+            branch="${BRANCHES[$i]}"
+            if git merge-base --is-ancestor "$commit_hash" "$ref" 2>/dev/null; then
+                key="${sha_lower}:${branch}"
+                if [[ -z "${GREP_HITS[$key]:-}" ]]; then
+                    GREP_HITS["$key"]="$entry"
+                    GREP_HIT_COUNTS["$key"]=1
+                else
+                    GREP_HIT_COUNTS["$key"]=$(( ${GREP_HIT_COUNTS["$key"]} + 1 ))
+                fi
+            fi
+        done
+    done
+done
+
+# ── Phase 2: direct ancestry check (--contains) ─────────────────────
+# For each SHA, check if the actual upstream commit object exists locally
+# and is an ancestor of each branch. This is fast — no log walk needed.
+
+declare -A CONTAINS_HITS  # CONTAINS_HITS["sha:branch"] = 1
+
+for sha in "${SHA_LIST[@]}"; do
+    sha_lower="$(echo "$sha" | tr '[:upper:]' '[:lower:]')"
+    full_sha=""
+    if git cat-file -t "$sha_lower" >/dev/null 2>&1; then
+        full_sha="$(git rev-parse "$sha_lower" 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$full_sha" ]]; then
+        continue
+    fi
+
+    for i in "${!BRANCHES[@]}"; do
+        ref="${REFS[$i]}"
+        branch="${BRANCHES[$i]}"
+        if git merge-base --is-ancestor "$full_sha" "$ref" 2>/dev/null; then
+            CONTAINS_HITS["${sha_lower}:${branch}"]=1
+        fi
+    done
+done
+
+# ── Output ───────────────────────────────────────────────────────────
+
+if [[ $JSON -eq 1 ]]; then
+    json_results="["
+    json_first_sha=1
+fi
+
+for sha in "${SHA_LIST[@]}"; do
+    sha_lower="$(echo "$sha" | tr '[:upper:]' '[:lower:]')"
+
+    full_sha=""
+    if git cat-file -t "$sha_lower" >/dev/null 2>&1; then
+        full_sha="$(git rev-parse "$sha_lower" 2>/dev/null || true)"
+    fi
+
+    if [[ $JSON -eq 0 ]]; then
+        echo ""
+        echo "━━━ Checking ${sha_lower} ━━━"
+        if [[ -n "$full_sha" && "$full_sha" != "$sha_lower" ]]; then
+            echo "    (resolved to ${full_sha})"
+        fi
+        echo ""
+        printf "  %-35s  %-10s  %-10s  %s\n" "BRANCH" "CONTAINS" "BACKPORT" "DETAILS"
+        printf "  %-35s  %-10s  %-10s  %s\n" "------" "--------" "--------" "-------"
+    else
+        if [[ $json_first_sha -eq 0 ]]; then json_results+=","; fi
+        json_first_sha=0
+        json_results+="{\"sha\":\"${sha_lower}\""
+        [[ -n "$full_sha" ]] && json_results+=",\"full_sha\":\"${full_sha}\""
+        json_results+=",\"branches\":["
+        json_first_branch=1
+    fi
+
+    for branch in "${BRANCHES[@]}"; do
+        label="$(branch_label "$branch")"
+        key="${sha_lower}:${branch}"
+        contains="no"
+        backport="no"
+        details=""
+
+        if [[ -n "${CONTAINS_HITS[$key]:-}" ]]; then
+            contains="YES"
+        fi
+
+        if [[ -n "${GREP_HITS[$key]:-}" ]]; then
+            backport="YES"
+            count="${GREP_HIT_COUNTS[$key]:-1}"
+            if [[ $VERBOSE -eq 1 ]]; then
+                entry="${GREP_HITS[$key]}"
+                match_sha="${entry%% *}"
+                match_subj="${entry#* }"
+                details="${match_sha:0:12} ${match_subj}"
+                if [[ $count -gt 1 ]]; then
+                    details+=" (+$((count - 1)) more)"
+                fi
+            else
+                if [[ $count -gt 1 ]]; then
+                    details="${count} commits reference this SHA"
+                fi
+            fi
+        fi
+
+        if [[ $QUIET -eq 1 && "$contains" == "no" && "$backport" == "no" ]]; then
+            continue
+        fi
+
+        if [[ $JSON -eq 0 ]]; then
+            if [[ -t 1 ]]; then
+                c_green="\033[32m"
+                c_reset="\033[0m"
+                c_dim="\033[2m"
+                [[ "$contains" == "YES" ]] && c_cont="${c_green}YES${c_reset}" || c_cont="${c_dim}no${c_reset} "
+                [[ "$backport" == "YES" ]] && c_back="${c_green}YES${c_reset}" || c_back="${c_dim}no${c_reset} "
+                printf "  %-35s  ${c_cont}%-4s      ${c_back}%-4s      %s\n" "$label" "" "" "$details"
+            else
+                printf "  %-35s  %-10s  %-10s  %s\n" "$label" "$contains" "$backport" "$details"
+            fi
+        else
+            if [[ $json_first_branch -eq 0 ]]; then json_results+=","; fi
+            json_first_branch=0
+            json_results+="{\"branch\":\"${branch}\",\"label\":\"${label}\""
+            json_results+=",\"contains\":$([ "$contains" = "YES" ] && echo true || echo false)"
+            json_results+=",\"backport\":$([ "$backport" = "YES" ] && echo true || echo false)"
+            if [[ -n "$details" ]]; then
+                details_escaped="${details//\\/\\\\}"
+                details_escaped="${details_escaped//\"/\\\"}"
+                json_results+=",\"details\":\"${details_escaped}\""
+            fi
+            json_results+="}"
+        fi
+    done
+
+    if [[ $JSON -eq 1 ]]; then
+        json_results+="]}"
+    fi
+
+    if [[ $JSON -eq 0 && $QUIET -eq 0 ]]; then
+        echo ""
+    fi
+done
+
+if [[ $JSON -eq 1 ]]; then
+    json_results+="]"
+    echo "$json_results"
+fi


### PR DESCRIPTION
This is a quickly written script that Claude built based off many of LPE and embargo's we've needed to address over the past 3 months.  This should be decomposed into kt libraries more specifically but is here just so we have something to share quickly.

NOTE ITS PRETTY SLOW but that is less important than the information at the moment

## example with Januscape
```
[jmaple@devbox kernel-src-tree]$ ../check-upstream-commit.sh 2032a93d66fa

━━━ Checking 2032a93d66fa ━━━
    (resolved to 2032a93d66fa282ba0f2ea9152eeff9511fa9a96)

  BRANCH                               CONTAINS    BACKPORT    DETAILS
  ------                               --------    --------    -------
  CBR 7.9                              YES          no
  LTS 8.6                              YES          YES          2 commits reference this SHA
  LTS 8.8                              YES          no
  LTS 9.2                              YES          YES          2 commits reference this SHA
  LTS 9.4                              YES          no
  LTS 9.6                              YES          YES          2 commits reference this SHA
  CLK 6.12                             YES          YES          2 commits reference this SHA
  CLK 6.18                             YES          YES          2 commits reference this SHA
  RLC 8 (4.18.0-553.148.1.el8_10)      YES          YES
  RLC 9 (5.14.0-687.31.1.el9_8)        YES          YES          2 commits reference this SHA
  RLC 10 (6.12.0-211.39.1.el10_2)      YES          YES          2 commits reference this SHA
```
<!-- coverage-report -->
## Coverage Report

| Name                          |    Stmts |     Miss |   Branch |   BrPart |   Cover |   Missing |
|------------------------------ | -------: | -------: | -------: | -------: | ------: | --------: |
| check\_fips\_changes.py       |       42 |       42 |       12 |        0 |      0% |      8-67 |
| check\_kernel\_commits.py     |      179 |      179 |       76 |        0 |      0% |     3-371 |
| ciq-cherry-pick.py            |      190 |      190 |       50 |        0 |      0% |     1-426 |
| ciq-tag.py                    |      146 |      146 |       16 |        0 |      0% |     3-378 |
| ciq\_tag.py                   |      232 |      232 |       54 |        0 |      0% |     1-464 |
| jira\_pr\_check.py            |      180 |      180 |       80 |        0 |      0% |     3-381 |
| kt/ktlib/command\_runner.py   |       33 |       20 |        6 |        0 |     33% |16, 20-33, 37-61, 65-66 |
| kt/ktlib/config.py            |       47 |        4 |        8 |        2 |     89% | 52, 82-85 |
| kt/ktlib/kernel\_workspace.py |      111 |       77 |       18 |        0 |     26% |22-35, 49-66, 73-76, 80-91, 94-100, 113-124, 135-145, 162-165, 169-202, 210-213, 216-220 |
| kt/ktlib/kernels.py           |       78 |       16 |       12 |        2 |     78% |54-62, 79-81, 111, 127-134 |
| kt/ktlib/local.py             |        5 |        1 |        0 |        0 |     80% |        12 |
| kt/ktlib/repo.py              |       29 |       15 |        2 |        0 |     45% |30-31, 34-35, 43-55 |
| kt/ktlib/ssh.py               |       10 |        2 |        0 |        0 |     80% |    10, 14 |
| kt/ktlib/util.py              |       14 |        0 |        0 |        0 |    100% |           |
| kt/ktlib/virt.py              |       64 |       29 |        2 |        0 |     53% |23, 31-34, 47-69, 73-79, 83-84, 88, 92, 96, 100, 106-108, 112-117, 121-126 |
| kt/ktlib/vm.py                |      243 |      120 |       36 |        0 |     48% |120-133, 161-170, 178-189, 256-266, 269, 281-285, 288, 291-307, 310-317, 326-330, 333-344, 347-348, 351, 355-360, 372-383, 396-403, 412, 421-433, 436-443, 446-455, 458 |
| release\_config.py            |        2 |        2 |        0 |        0 |      0% |      7-27 |
| rolling-release-update.py     |      264 |      264 |      106 |        0 |      0% |     1-412 |
| run\_interdiff.py             |      165 |      165 |       56 |        0 |      0% |     3-244 |
| update\_lt\_spec.py           |      219 |      219 |       46 |        0 |      0% |     9-411 |
| **TOTAL**                     | **2253** | **1903** |  **580** |    **4** | **13%** |           |
