### PR TITLE
[KT] Fix VM ssh auth and CentOS7 content-release

### DIFF
--- a/kt/commands/content_release/impl.py
+++ b/kt/commands/content_release/impl.py
@@ -307,7 +307,11 @@ class ContentRelease:
 
         # Wait for dependencies to be installed if VM was just created
         logging.info("Waiting for VM dependencies to be installed...")
-        SshCommand.run(domain=vm_instance.domain, command=["sudo cloud-init status --wait || true"])
+        SshCommand.run(
+            domain=vm_instance.domain,
+            command=["sudo cloud-init status --wait || true"],
+            ssh_key=vm_instance.ssh_key,
+        )
 
         # Install the built RPMs
         build_files_dir = kernel_workspace_obj.folder / "build_files"
@@ -331,17 +335,22 @@ class ContentRelease:
                     command=[
                         'sudo dnf install -y "https://depot.ciq.com/public/files/depot-client/depot/depot.x86_64.rpm"'
                     ],
+                    ssh_key=vm_instance.ssh_key,
                 )
                 logging.info("Depot client installed")
 
                 # Register depot with credentials
                 SshCommand.run(
-                    domain=vm_instance.domain, command=[f"sudo depot register -u {depot_user} -t {depot_token}"]
+                    domain=vm_instance.domain,
+                    command=[f"sudo depot register -u {depot_user} -t {depot_token}"],
+                    ssh_key=vm_instance.ssh_key,
                 )
                 logging.info("Depot registered")
 
                 # Enable fips-legacy-8
-                SshCommand.run(domain=vm_instance.domain, command=["sudo depot enable fips-legacy-8"])
+                SshCommand.run(
+                    domain=vm_instance.domain, command=["sudo depot enable fips-legacy-8"], ssh_key=vm_instance.ssh_key
+                )
                 logging.info("fips-legacy-8 enabled via depot")
             except RuntimeError as e:
                 logging.error(f"Failed to enable depot for fipslegacy-8.6: {e}")
@@ -372,7 +381,9 @@ class ContentRelease:
         logging.info(f"RPM install output will be written to {install_log}")
 
         try:
-            SshCommand.run_with_output(output_file=install_log, domain=vm_instance.domain, command=[install_cmd])
+            SshCommand.run_with_output(
+                output_file=install_log, domain=vm_instance.domain, command=[install_cmd], ssh_key=vm_instance.ssh_key
+            )
             logging.info("RPMs installed successfully")
         except RuntimeError as e:
             logging.error(f"RPM installation failed: {e}")
@@ -407,7 +418,7 @@ class ContentRelease:
             "fi'"
         )
         try:
-            SshCommand.run(domain=vm_instance.domain, command=[grubenv_fix_cmd])
+            SshCommand.run(domain=vm_instance.domain, command=[grubenv_fix_cmd], ssh_key=vm_instance.ssh_key)
             logging.info("grubenv symlink fixed if needed")
         except RuntimeError as e:
             logging.error(f"Failed to fix grubenv symlink: {e}")
@@ -419,7 +430,7 @@ class ContentRelease:
             kernel_path = f"/boot/vmlinuz-{expected_version}"
             set_default_cmd = f"sudo grubby --set-default={kernel_path}"
             try:
-                SshCommand.run(domain=vm_instance.domain, command=[set_default_cmd])
+                SshCommand.run(domain=vm_instance.domain, command=[set_default_cmd], ssh_key=vm_instance.ssh_key)
                 logging.info("Default boot kernel set successfully")
             except RuntimeError as e:
                 logging.error(f"Failed to set default boot kernel: {e}")

--- a/kt/commands/content_release/impl.py
+++ b/kt/commands/content_release/impl.py
@@ -6,6 +6,7 @@ from git import GitCommandError, Repo
 
 from kt.ktlib.config import Config
 from kt.ktlib.kernel_workspace import KernelWorkspace
+from kt.ktlib.kernels import KernelsInfo
 from kt.ktlib.local import LocalCommand
 from kt.ktlib.mock import Mock
 from kt.ktlib.ssh import SshCommand
@@ -302,16 +303,30 @@ class ContentRelease:
         # Load kernel workspace
         kernel_workspace_obj = KernelWorkspace.load_from_name(kernel_workspace)
 
+        # Determine package manager based on OS variant
+        config = Config.load()
+        kernels_info = KernelsInfo.from_yaml(config)
+        kernel_name = Vm._extract_kernel_name(kernel_workspace)
+        kernel_info = kernels_info.kernels.get(kernel_name)
+        pkg_mgr = "yum" if (kernel_info and (kernel_info.os_variant or "").startswith("centos7")) else "dnf"
+
         # Setup and spin up the VM (reuses common code from vm command)
         vm_instance = Vm.setup_and_spinup(kernel_workspace_name=kernel_workspace)
 
-        # Wait for dependencies to be installed if VM was just created
+        # Wait for cloud-init to finish (may reboot the VM, e.g. CentOS 7)
         logging.info("Waiting for VM dependencies to be installed...")
-        SshCommand.run(
-            domain=vm_instance.domain,
-            command=["sudo cloud-init status --wait || true"],
-            ssh_key=vm_instance.ssh_key,
-        )
+        try:
+            SshCommand.run(
+                domain=vm_instance.domain,
+                command=["sudo cloud-init status --wait || true"],
+                ssh_key=vm_instance.ssh_key,
+            )
+        except RuntimeError as e:
+            if "closed by remote host" in str(e):
+                logging.info("VM rebooted during cloud-init, waiting for it to come back...")
+                vm_instance._wait_for_ssh()
+            else:
+                raise
 
         # Install the built RPMs
         build_files_dir = kernel_workspace_obj.folder / "build_files"
@@ -370,11 +385,13 @@ class ContentRelease:
             raise RuntimeError(f"No installable RPMs found in {build_files_dir}")
 
         rpm_paths = " ".join(str(rpm.absolute()) for rpm in install_rpms)
-        # Remove libtraceevent first to avoid file conflicts with perf package
-        install_cmd = (
-            f"sudo dnf remove -y libtraceevent || true && sudo dnf install --skip-broken --allowerasing {rpm_paths} -y"
-        )
-        # install_cmd = f"sudo dnf clean all && sudo dnf install --skip-broken --allowerasing {rpm_paths} -y"
+        if pkg_mgr == "yum":
+            install_cmd = f"sudo yum install -y {rpm_paths}"
+        else:
+            install_cmd = (
+                f"sudo dnf remove -y libtraceevent || true && "
+                f"sudo dnf install --skip-broken --allowerasing {rpm_paths} -y"
+            )
 
         install_log = kernel_workspace_obj.folder.absolute() / "install.log"
         logging.info(f"Installing {len(install_rpms)} RPM(s)")
@@ -449,11 +466,12 @@ class ContentRelease:
             raise RuntimeError(f"Kernel version mismatch! Expected: {expected_version}, Running: {kernel_version}")
         logging.info("Verified VM is running the newly installed kernel")
 
-        # Run kselftests using the installed kselftests
-        kselftest_log = kernel_workspace_obj.folder.absolute() / f"selftest-{kernel_version}.log"
-        vm_instance.kselftests_internal(kselftest_log)
-
-        # Count passed tests
-        vm_instance.count_kselftest_passed(kselftest_log)
+        # Run kselftests using the installed kselftests (not available on CentOS 7)
+        if pkg_mgr == "yum":
+            logging.info("Skipping kselftests (not available on CentOS 7)")
+        else:
+            kselftest_log = kernel_workspace_obj.folder.absolute() / f"selftest-{kernel_version}.log"
+            vm_instance.kselftests_internal(kselftest_log)
+            vm_instance.count_kselftest_passed(kselftest_log)
 
         logging.info("Test step completed successfully")

--- a/kt/commands/content_release/impl.py
+++ b/kt/commands/content_release/impl.py
@@ -315,18 +315,7 @@ class ContentRelease:
 
         # Wait for cloud-init to finish (may reboot the VM, e.g. CentOS 7)
         logging.info("Waiting for VM dependencies to be installed...")
-        try:
-            SshCommand.run(
-                domain=vm_instance.domain,
-                command=["sudo cloud-init status --wait || true"],
-                ssh_key=vm_instance.ssh_key,
-            )
-        except RuntimeError as e:
-            if "closed by remote host" in str(e):
-                logging.info("VM rebooted during cloud-init, waiting for it to come back...")
-                vm_instance._wait_for_ssh()
-            else:
-                raise
+        vm_instance.wait_for_cloud_init()
 
         # Install the built RPMs
         build_files_dir = kernel_workspace_obj.folder / "build_files"

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -43,7 +43,11 @@ def main(
 
     if test:
         logging.info("Waiting for cloud-init to finish...")
-        SshCommand.run(domain=vm_instance.domain, command=["sudo cloud-init status --wait || true"])
+        SshCommand.run(
+            domain=vm_instance.domain,
+            command=["sudo cloud-init status --wait || true"],
+            ssh_key=vm_instance.ssh_key,
+        )
         vm_instance.test(config=config)
 
     if console:

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -1,7 +1,6 @@
 import logging
 
 from kt.ktlib.config import Config
-from kt.ktlib.ssh import SshCommand
 from kt.ktlib.virt import VmCommand
 from kt.ktlib.vm import Vm
 
@@ -43,18 +42,7 @@ def main(
 
     if test:
         logging.info("Waiting for cloud-init to finish...")
-        try:
-            SshCommand.run(
-                domain=vm_instance.domain,
-                command=["sudo cloud-init status --wait || true"],
-                ssh_key=vm_instance.ssh_key,
-            )
-        except RuntimeError as e:
-            if "closed by remote host" in str(e):
-                logging.info("VM rebooted during cloud-init, waiting for it to come back...")
-                vm_instance._wait_for_ssh()
-            else:
-                raise
+        vm_instance.wait_for_cloud_init()
         vm_instance.test(config=config)
 
     if console:

--- a/kt/commands/vm/impl.py
+++ b/kt/commands/vm/impl.py
@@ -43,11 +43,18 @@ def main(
 
     if test:
         logging.info("Waiting for cloud-init to finish...")
-        SshCommand.run(
-            domain=vm_instance.domain,
-            command=["sudo cloud-init status --wait || true"],
-            ssh_key=vm_instance.ssh_key,
-        )
+        try:
+            SshCommand.run(
+                domain=vm_instance.domain,
+                command=["sudo cloud-init status --wait || true"],
+                ssh_key=vm_instance.ssh_key,
+            )
+        except RuntimeError as e:
+            if "closed by remote host" in str(e):
+                logging.info("VM rebooted during cloud-init, waiting for it to come back...")
+                vm_instance._wait_for_ssh()
+            else:
+                raise
         vm_instance.test(config=config)
 
     if console:

--- a/kt/data/cloud_init_centos7.yaml
+++ b/kt/data/cloud_init_centos7.yaml
@@ -15,6 +15,10 @@ ssh_pwauth: true
 # Ensure the system does not update on boot.
 package_upgrade: False
 
+# Create mount point before mounts module runs
+bootcmd:
+  - mkdir -p SHARED_DIR_PLACEHOLDER
+
 mounts:
   - - NFS_SOURCE_PLACEHOLDER
     - SHARED_DIR_PLACEHOLDER

--- a/kt/ktlib/ssh.py
+++ b/kt/ktlib/ssh.py
@@ -3,12 +3,14 @@ from kt.ktlib.command_runner import CommandRunner
 
 class SshCommand(CommandRunner):
     COMMAND = "ssh"
-    EXTRA = "-o StrictHostKeyChecking=no"
 
     @classmethod
-    def _build_command(cls, domain: str, command: list[str]) -> list[str]:
-        return [cls.COMMAND, cls.EXTRA, domain] + command
+    def _build_command(cls, domain: str, command: list[str], ssh_key: str | None = None) -> list[str]:
+        cmd = [cls.COMMAND, "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes"]
+        if ssh_key:
+            cmd += ["-i", ssh_key]
+        return cmd + [domain] + command
 
     @classmethod
-    def running_kernel_version(cls, domain):
-        return cls.run(domain=domain, command=["uname", "-r"])
+    def running_kernel_version(cls, domain, ssh_key: str | None = None):
+        return cls.run(domain=domain, command=["uname", "-r"], ssh_key=ssh_key)

--- a/kt/ktlib/virt.py
+++ b/kt/ktlib/virt.py
@@ -1,3 +1,6 @@
+import logging
+import re
+import time
 from enum import Enum
 
 from pathlib3x import Path
@@ -107,11 +110,23 @@ class VmCommand(CommandRunner):
 
 
 class VirtHelper:
+    IP_PATTERN = re.compile(r"\d+\.\d+\.\d+\.\d+")
+    IP_POLL_INTERVAL = 5
+    IP_POLL_MAX_ATTEMPTS = 24
+
     @classmethod
     def ip_addr(cls, vm_name: str) -> str:
-        rc = VmCommand.domifaddr(vm_name=vm_name)
-
-        return rc[-1].split("/")[0]
+        for attempt in range(cls.IP_POLL_MAX_ATTEMPTS):
+            output = VmCommand.domifaddr(vm_name=vm_name)
+            for token in output:
+                match = cls.IP_PATTERN.search(token)
+                if match:
+                    return match.group()
+            logging.info(f"Waiting for IP address for {vm_name} (attempt {attempt + 1}/{cls.IP_POLL_MAX_ATTEMPTS})...")
+            time.sleep(cls.IP_POLL_INTERVAL)
+        raise RuntimeError(
+            f"VM {vm_name} did not get an IP address after {cls.IP_POLL_MAX_ATTEMPTS * cls.IP_POLL_INTERVAL}s"
+        )
 
     @classmethod
     def is_running(cls, vm_name: str) -> bool:

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -407,6 +407,21 @@ class VmInstance:
             f"{Constants.VM_POLL_MAX_ATTEMPTS * Constants.VM_POLL_INTERVAL_SECONDS}s"
         )
 
+    def wait_for_cloud_init(self):
+        """ "Wait for cloud-init to finish on the VM. This method will block until cloud-init has completed its tasks."""
+        try:
+            SshCommand.run(
+                domain=self.domain,
+                command=["sudo cloud-init status --wait || true"],
+                ssh_key=self.ssh_key,
+            )
+        except RuntimeError as e:
+            if "closed by remote host" in str(e):
+                logging.info("VM rebooted during cloud-init, waiting for it to come back...")
+                self._wait_for_ssh()
+            else:
+                raise
+
     def reboot(self):
         logging.debug("Rebooting vm")
 

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -388,6 +388,23 @@ class VmInstance:
         self.kernel_workspace = kernel_workspace
         ssh_pub = str(config.ssh_key)
         self.ssh_key = ssh_pub.removesuffix(".pub") if ssh_pub.endswith(".pub") else ssh_pub
+        self._wait_for_ssh()
+
+    def _wait_for_ssh(self):
+        for attempt in range(Constants.VM_POLL_MAX_ATTEMPTS):
+            try:
+                SshCommand.run(domain=self.domain, command=["true"], ssh_key=self.ssh_key)
+                logging.info(f"SSH connection to {self.domain} established")
+                return
+            except RuntimeError:
+                logging.info(
+                    f"Waiting for SSH on {self.domain} (attempt {attempt + 1}/{Constants.VM_POLL_MAX_ATTEMPTS})..."
+                )
+                time.sleep(Constants.VM_POLL_INTERVAL_SECONDS)
+        raise RuntimeError(
+            f"SSH to {self.domain} not available after "
+            f"{Constants.VM_POLL_MAX_ATTEMPTS * Constants.VM_POLL_INTERVAL_SECONDS}s"
+        )
 
     def reboot(self):
         logging.debug("Rebooting vm")

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -351,19 +351,19 @@ class Vm:
 
             self._create_image(config=config, vcpus=vcpus, memory=memory, no_depot=no_depot)
             self._wait_for_running()
-            return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace)
+            return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace, config=config)
 
         logging.info(f"Vm {self.name} already exists")
 
         if VirtHelper.is_running(vm_name=self.name):
             logging.info(f"Vm {self.name} is running, nothing to do")
-            return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace)
+            return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace, config=config)
 
         logging.info(f"Vm {self.name} is not running, starting it")
         VmCommand.start(vm_name=self.name)
         self._wait_for_running()
 
-        return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace)
+        return VmInstance(name=self.name, kernel_workspace=self.kernel_workspace, config=config)
 
     def destroy(self):
         if VirtHelper.is_running(vm_name=self.name):
@@ -381,19 +381,20 @@ class VmInstance:
     ssh_domain: str
     kernel_workspace: KernelWorkspace
 
-    def __init__(self, name: str, kernel_workspace: KernelWorkspace):
+    def __init__(self, name: str, kernel_workspace: KernelWorkspace, config: Config):
         self.name = name
         ip_addr = VirtHelper.ip_addr(vm_name=self.name)
-        username = os.environ["USER"]
-        self.domain = f"{username}@{ip_addr}"
+        self.domain = f"{config.user}@{ip_addr}"
         self.kernel_workspace = kernel_workspace
+        ssh_pub = str(config.ssh_key)
+        self.ssh_key = ssh_pub.removesuffix(".pub") if ssh_pub.endswith(".pub") else ssh_pub
 
     def reboot(self):
         logging.debug("Rebooting vm")
 
         command = ["sudo", "reboot"]
         try:
-            SshCommand.run(domain=self.domain, command=command)
+            SshCommand.run(domain=self.domain, command=command, ssh_key=self.ssh_key)
         except RuntimeError as e:
             if "closed by remote host" in str(e):
                 pass
@@ -416,7 +417,7 @@ class VmInstance:
         output_file = self.kernel_workspace.folder.absolute() / Path(f"kselftest-{self.current_head_sha_short()}.log")
         ssh_cmd = f"cd {self.kernel_workspace.src_worktree.folder.absolute()} &&  sudo {script}"
 
-        SshCommand.run_with_output(output_file=output_file, domain=self.domain, command=[ssh_cmd])
+        SshCommand.run_with_output(output_file=output_file, domain=self.domain, command=[ssh_cmd], ssh_key=self.ssh_key)
 
     def kselftests_internal(self, output_file: Path):
         """
@@ -434,7 +435,9 @@ class VmInstance:
         kselftest_cmd = "sudo /usr/libexec/kselftests/run_kselftest.sh"
 
         try:
-            SshCommand.run_with_output(output_file=output_file, domain=self.domain, command=[kselftest_cmd])
+            SshCommand.run_with_output(
+                output_file=output_file, domain=self.domain, command=[kselftest_cmd], ssh_key=self.ssh_key
+            )
             logging.info("Kselftests completed successfully")
         except RuntimeError as e:
             logging.error(f"Kselftests failed: {e}")
@@ -468,7 +471,7 @@ class VmInstance:
         Returns:
             str: The kernel version string (e.g., "5.14.0-284.30.1+23.1.el9_2_ciq.x86_64")
         """
-        return SshCommand.running_kernel_version(domain=self.domain)
+        return SshCommand.running_kernel_version(domain=self.domain, ssh_key=self.ssh_key)
 
     def expected_kernel_version(self):
         """
@@ -499,7 +502,7 @@ class VmInstance:
         )
         ssh_cmd = f"cd {self.kernel_workspace.src_worktree.folder.absolute()} &&  {build_script} -n"
 
-        SshCommand.run_with_output(output_file=output_file, domain=self.domain, command=[ssh_cmd])
+        SshCommand.run_with_output(output_file=output_file, domain=self.domain, command=[ssh_cmd], ssh_key=self.ssh_key)
 
     def test(self, config):
         if self.expected_kernel_version():

--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -232,6 +232,7 @@ class Vm:
         base_path_str = str(config.base_path.absolute())
         if self._is_centos7():
             nfs_source = f"{Constants.LIBVIRT_HOST_IP}:{base_path_str}"
+            data["bootcmd"][0] = f"mkdir -p {base_path_str}"
             data["mounts"][0][0] = nfs_source
             data["mounts"][0][1] = base_path_str
             data["mounts"][1][0] = base_path_str

--- a/tests/kt/ktlib/test_vm.py
+++ b/tests/kt/ktlib/test_vm.py
@@ -1,12 +1,13 @@
 import os
 from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+import pytest
 from ruamel.yaml import YAML
 from pathlib3x import Path
 
 from kt.ktlib.util import Constants
-from kt.ktlib.vm import Vm
+from kt.ktlib.vm import Vm, VmInstance
 
 _real_open = open
 
@@ -225,3 +226,61 @@ def test_cloud_init_no_depot_skips_depot_install():
     runcmd_strs = [str(c) for c in runcmd]
     assert not any("depot.x86_64.rpm" in s for s in runcmd_strs)
     assert any("kernel_install_dep.sh" in s for s in runcmd_strs)
+
+
+def _make_vm_instance(**overrides):
+    inst = VmInstance.__new__(VmInstance)
+    inst.name = "lts-9.2"
+    inst.domain = "testuser@192.168.122.10"
+    inst.kernel_workspace = MagicMock()
+    inst.ssh_key = "/tmp/fake_key"
+    for k, v in overrides.items():
+        setattr(inst, k, v)
+    return inst
+
+
+@patch("kt.ktlib.vm.SshCommand.run")
+def test_wait_for_cloud_init_success(mock_ssh_run):
+    """cloud-init finishes normally, no reboot."""
+    inst = _make_vm_instance()
+    inst.wait_for_cloud_init()
+
+    mock_ssh_run.assert_called_once_with(
+        domain="testuser@192.168.122.10",
+        command=["sudo cloud-init status --wait || true"],
+        ssh_key="/tmp/fake_key",
+    )
+
+
+@patch("kt.ktlib.vm.time.sleep")
+@patch("kt.ktlib.vm.SshCommand.run")
+def test_wait_for_cloud_init_reboot_recovery(mock_ssh_run, mock_sleep):
+    """cloud-init reboots the VM, then SSH comes back."""
+    mock_ssh_run.side_effect = [
+        RuntimeError("Connection to 192.168.122.10 closed by remote host."),
+        None,  # _wait_for_ssh -> "true" succeeds
+    ]
+    inst = _make_vm_instance()
+    inst.wait_for_cloud_init()
+
+    assert mock_ssh_run.call_count == 2
+    assert mock_ssh_run.call_args_list[0] == call(
+        domain="testuser@192.168.122.10",
+        command=["sudo cloud-init status --wait || true"],
+        ssh_key="/tmp/fake_key",
+    )
+    assert mock_ssh_run.call_args_list[1] == call(
+        domain="testuser@192.168.122.10",
+        command=["true"],
+        ssh_key="/tmp/fake_key",
+    )
+
+
+@patch("kt.ktlib.vm.SshCommand.run")
+def test_wait_for_cloud_init_other_error_raises(mock_ssh_run):
+    """Non-reboot SSH errors propagate."""
+    mock_ssh_run.side_effect = RuntimeError("Permission denied")
+    inst = _make_vm_instance()
+
+    with pytest.raises(RuntimeError, match="Permission denied"):
+        inst.wait_for_cloud_init()


### PR DESCRIPTION
In order to do the full content release for CentOS7 the tooling needs to use the SSH details from the configs rather than defaulting to USER.  In addition there where VM and SSH readiness improvements. CentOS7 needed some NFS and reliability updates that worked fine for just general vm creation but caused issues during content release. Skip Kselftess for CentOS7.

was used todo current release.

```
(.venv) [jmaple@devbox kernel-src-tree]$ kt checkout --cleanup cbr-7.9 && kt checkout cbr-7.9 && kt vm --destroy cbr-7.9 && kt vm cbr-7.9 -c && sleep 60  && virsh start cbr-7.9 && sleep 300 &&  kt content-release cbr-7.9 | tee cbr-7.9_content_release.log
```
## V2
Addressed feed back and had claude restructure the commits to force push

<!-- coverage-report -->
## Coverage Report

| Name                          |    Stmts |     Miss |   Branch |   BrPart |   Cover |   Missing |
|------------------------------ | -------: | -------: | -------: | -------: | ------: | --------: |
| check\_fips\_changes.py       |       42 |       42 |       12 |        0 |      0% |      8-67 |
| check\_kernel\_commits.py     |      179 |      179 |       76 |        0 |      0% |     3-371 |
| ciq-cherry-pick.py            |      190 |      190 |       50 |        0 |      0% |     1-426 |
| ciq-tag.py                    |      146 |      146 |       16 |        0 |      0% |     3-378 |
| ciq\_tag.py                   |      232 |      232 |       54 |        0 |      0% |     1-464 |
| jira\_pr\_check.py            |      180 |      180 |       80 |        0 |      0% |     3-381 |
| kt/ktlib/command\_runner.py   |       33 |       20 |        6 |        0 |     33% |16, 20-33, 37-61, 65-66 |
| kt/ktlib/config.py            |       54 |        0 |       12 |        0 |    100% |           |
| kt/ktlib/kernel\_workspace.py |      111 |       77 |       18 |        0 |     26% |22-35, 49-66, 73-76, 80-91, 94-100, 113-124, 135-145, 162-165, 169-202, 210-213, 216-220 |
| kt/ktlib/kernels.py           |       85 |       13 |       14 |        1 |     84% |57-65, 119, 135-142 |
| kt/ktlib/local.py             |        5 |        1 |        0 |        0 |     80% |        12 |
| kt/ktlib/repo.py              |       29 |       15 |        2 |        0 |     45% |30-31, 34-35, 43-55 |
| kt/ktlib/ssh.py               |       12 |        5 |        2 |        0 |     50% |  9-12, 16 |
| kt/ktlib/util.py              |       17 |        0 |        0 |        0 |    100% |           |
| kt/ktlib/virt.py              |       80 |       39 |       10 |        0 |     46% |26, 34-37, 51-78, 82-88, 92-93, 97, 101, 105, 109, 119-127, 133-138, 142-147 |
| kt/ktlib/vm.py                |      302 |      152 |       52 |        4 |     47% |127-144, 177-186, 194-205, 234-238, 253-\>264, 281-\>287, 292-302, 305-306, 319-323, 326, 329-345, 350-367, 370-377, 386-392, 400-405, 426-437, 440-441, 444, 448-453, 465-478, 491-498, 507, 516-528, 531-538, 541-550, 553 |
| release\_config.py            |        2 |        2 |        0 |        0 |      0% |      7-27 |
| rolling-release-update.py     |      264 |      264 |      106 |        0 |      0% |     1-412 |
| run\_interdiff.py             |      165 |      165 |       56 |        0 |      0% |     3-244 |
| update\_lt\_spec.py           |      219 |      219 |       46 |        0 |      0% |     9-411 |
| **TOTAL**                     | **2347** | **1941** |  **612** |    **5** | **15%** |           |
