### PR TITLE
ciq-cherry-pick.py: Fix two commit message defects

### DIFF
--- a/ciq-cherry-pick.py
+++ b/ciq-cherry-pick.py
@@ -179,6 +179,14 @@ def manage_commit_message(full_sha, ciq_tags, jira_ticket, commit_successful):
     except IOError as e:
         raise RuntimeError(f"Failed to read commit message from {MERGE_MSG}: {e}") from e
 
+    # git appends a "# Conflicts:" comment block to MERGE_MSG on a conflicted
+    # cherry-pick, and committing with -F doesn't strip comment lines. Drop the
+    # block to keep it out of the final commit message.
+    for i, line in enumerate(original_msg):
+        if line.rstrip("\n") == "# Conflicts:":
+            original_msg = original_msg[:i]
+            break
+
     optional_msg = "" if commit_successful else "upstream-diff |"
     new_msg = CIQ_cherry_pick_commit_standardization(
         original_msg, full_sha, jira=jira_ticket, tags=new_tags, optional_msg=optional_msg

--- a/kt/ktlib/ciq_helpers.py
+++ b/kt/ktlib/ciq_helpers.py
@@ -134,8 +134,8 @@ def CIQ_cherry_pick_commit_standardization(lines, commit, tags=None, jira="", op
     # will atttempt to read these lines and email everyone on the list.  We do not want
     # to annoy the community when doing our own work.
     for i in range(5, len(lines)):
-        # The (cherry Picked from commit: <sha1>) line is the indicator we cherry-picked
-        if lines[i].startswith("cherry picked from commit"):
+        # The (cherry picked from commit <sha1>) line is the indicator we cherry-picked
+        if lines[i].lstrip().startswith("(cherry picked from commit"):
             break
         if (
             lines[i].startswith("Signed-off-by")

--- a/tests/kt/ktlib/test_ciq_helpers.py
+++ b/tests/kt/ktlib/test_ciq_helpers.py
@@ -1,0 +1,31 @@
+from kt.ktlib.ciq_helpers import CIQ_cherry_pick_commit_standardization
+
+UPSTREAM_SHA = "1234567890abcdef1234567890abcdef12345678"
+AUTHOR_TAG = "commit-author Upstream Author <author@example.com>"
+
+
+def standardized_cherry_pick_msg():
+    """Run standardization on commit message lines mimicking MERGE_MSG after `git cherry-pick -nsx`."""
+    lines = [
+        "gve: fix a bug in the driver\n",
+        "\n",
+        "Some body text describing the fix.\n",
+        "\n",
+        "Signed-off-by: Upstream Author <author@example.com>\n",
+        "Reviewed-by: Upstream Reviewer <reviewer@example.com>\n",
+        f"(cherry picked from commit {UPSTREAM_SHA})\n",
+        "Signed-off-by: Backporter <backporter@example.com>\n",
+    ]
+    return CIQ_cherry_pick_commit_standardization(lines, UPSTREAM_SHA, tags=[AUTHOR_TAG], jira="VULN-123")
+
+
+def test_cherry_pick_standardization_indents_upstream_trailers():
+    lines = standardized_cherry_pick_msg()
+    assert "\tSigned-off-by: Upstream Author <author@example.com>\n" in lines
+    assert "\tReviewed-by: Upstream Reviewer <reviewer@example.com>\n" in lines
+
+
+def test_cherry_pick_standardization_stops_indenting_at_marker():
+    lines = standardized_cherry_pick_msg()
+    assert lines[-2] == f"(cherry picked from commit {UPSTREAM_SHA})\n"
+    assert lines[-1] == "Signed-off-by: Backporter <backporter@example.com>\n"


### PR DESCRIPTION
Both fixes target the standardized commit message that `ciq-cherry-pick.py` writes to MERGE_MSG. I noticed the first defect while reviewing the gve backport series on ctrliq/kernel-src-tree PRs 1496, 1498, and 1523: every backport in the series has its trailing Signed-off-by tab-indented (e.g., d5596b7488851, b862126f2c9ce, 2d48036cc4997) when it should sit at column 0.

**The trailer-indent loop never stops at the cherry-pick marker.** The loop in `CIQ_cherry_pick_commit_standardization()` is meant to quit indenting once it reaches the marker line, but it tests for a line starting with `cherry picked from commit` while git writes `(cherry picked from commit <sha>)`. The leading parenthesis means the break never fires, so the loop runs past the marker and indents the backporter's own Signed-off-by, which `cherry-pick -s` appends below the marker. Fixed by matching the line git actually writes.

**git's conflict comment block leaks into the final message.** On a conflicted pick, git appends `# Conflicts:` plus `#<TAB><path>` comment lines to MERGE_MSG. `manage_commit_message()` reads MERGE_MSG, inserts the CIQ header, and writes the whole thing back, conflict comments included. The script then exits telling the user to resolve and commit, and committing with `git commit -F .git/MERGE_MSG` keeps those lines, since -F's default cleanup mode only strips whitespace, not comments. I reproduced this on a live conflicted pick: the `# Conflicts:` block landed in the final commit message verbatim. Fixed by dropping the tail of the message starting at the line that is exactly `# Conflicts:`. The fix deliberately doesn't filter every `#` line, since legitimate upstream commit bodies can contain them.

The first fix comes with tests in `tests/kt/ktlib/test_ciq_helpers.py`, following the existing pytest layout. `manage_commit_message()` isn't importable from a test (the module builds `git.Repo(os.getcwd())` and imports `jira` at load time), so I verified it by exec'ing the function in isolation against a synthetic conflicted MERGE_MSG, alongside a negative control showing the old marker check misbehaving:

```
PASS: both tests in tests/kt/ktlib/test_ciq_helpers.py
PASS: negative control, mainline tab-indents the backporter Signed-off-by (defect A reproduced)
--- standardized MERGE_MSG (conflicted pick) ---
gve: fix a bug in the driver

jira VULN-123
cve CVE-2026-1234
commit-author Upstream Author <author@example.com>
commit 1234567890abcdef1234567890abcdef12345678
upstream-diff |

Some body text describing the fix.
# earlier body line starting with hash must survive

<TAB>Signed-off-by: Upstream Author <author@example.com>
(cherry picked from commit 1234567890abcdef1234567890abcdef12345678)
Signed-off-by: Backporter <backporter@example.com>

--- end ---
PASS: conflict block dropped; earlier '#' body line survives; marker and backporter Signed-off-by untouched
```

Generated with [Claude Code](https://claude.com/claude-code)
<!-- coverage-report -->
## Coverage Report

| Name                          |    Stmts |     Miss |   Branch |   BrPart |   Cover |   Missing |
|------------------------------ | -------: | -------: | -------: | -------: | ------: | --------: |
| check\_fips\_changes.py       |       42 |       42 |       12 |        0 |      0% |      8-67 |
| check\_kernel\_commits.py     |      179 |      179 |       76 |        0 |      0% |     3-371 |
| ciq-cherry-pick.py            |      194 |      194 |       54 |        0 |      0% |     1-434 |
| ciq-tag.py                    |      146 |      146 |       16 |        0 |      0% |     3-378 |
| ciq\_tag.py                   |      232 |      232 |       54 |        0 |      0% |     1-464 |
| jira\_pr\_check.py            |      180 |      180 |       80 |        0 |      0% |     3-381 |
| kt/ktlib/ciq\_helpers.py      |      325 |      269 |      152 |        4 |     14% |31-51, 74-106, 124, 126-\>129, 129-\>136, 136-\>151, 162-172, 179-183, 187, 191-199, 208-209, 213, 217, 225-229, 240-255, 263-266, 277-314, 327-333, 346-347, 351-353, 359, 363-369, 380-382, 390-395, 404-406, 415-420, 431-444, 455-479, 489-503, 513-518, 527, 557-623, 632-642, 646-655, 665-680, 692-709 |
| kt/ktlib/command\_runner.py   |       33 |       20 |        6 |        0 |     33% |16, 20-33, 37-61, 65-66 |
| kt/ktlib/config.py            |       54 |        0 |       12 |        0 |    100% |           |
| kt/ktlib/kernel\_workspace.py |      111 |       77 |       18 |        0 |     26% |22-35, 49-66, 73-76, 80-91, 94-100, 113-124, 135-145, 162-165, 169-202, 210-213, 216-220 |
| kt/ktlib/kernels.py           |       85 |       13 |       14 |        1 |     84% |57-65, 119, 135-142 |
| kt/ktlib/local.py             |        5 |        1 |        0 |        0 |     80% |        12 |
| kt/ktlib/repo.py              |       29 |       15 |        2 |        0 |     45% |30-31, 34-35, 43-55 |
| kt/ktlib/ssh.py               |       12 |        5 |        2 |        0 |     50% |  9-12, 16 |
| kt/ktlib/util.py              |       17 |        0 |        0 |        0 |    100% |           |
| kt/ktlib/virt.py              |       80 |       39 |       10 |        0 |     46% |26, 34-37, 51-78, 82-88, 92-93, 97, 101, 105, 109, 119-127, 133-138, 142-147 |
| kt/ktlib/vm.py                |      302 |      152 |       52 |        4 |     47% |127-144, 177-186, 194-205, 234-238, 253-\>264, 281-\>287, 292-302, 305-306, 319-323, 326, 329-345, 350-367, 370-377, 386-392, 400-405, 426-437, 440-441, 444, 448-453, 465-478, 491-498, 507, 516-528, 531-538, 541-550, 553 |
| release\_config.py            |        2 |        2 |        0 |        0 |      0% |      7-27 |
| rolling-release-update.py     |      264 |      264 |      106 |        0 |      0% |     1-412 |
| run\_interdiff.py             |      165 |      165 |       56 |        0 |      0% |     3-244 |
| update\_lt\_spec.py           |      219 |      219 |       46 |        0 |      0% |     9-411 |
| **TOTAL**                     | **2676** | **2214** |  **768** |    **9** | **15%** |           |
