### PR TITLE
[ULS] Update for Rocky version agnostic specs

### DIFF
--- a/kt/ktlib/ciq_helpers.py
+++ b/kt/ktlib/ciq_helpers.py
@@ -521,10 +521,14 @@ def _read_spec_define(spec_lines, name, value_pattern):
 def read_spec_el_version(spec_lines):
     """Read the EL version number from spec file lines.
 
-    Returns the el_version string (e.g., '9').
-    Raises ValueError if not found.
+    Returns the el_version string (e.g., '9'), or None if %define el_version
+    is not present in the spec or its value does not match the expected
+    numeric pattern.
     """
-    return _read_spec_define(spec_lines, "el_version", r"\d+")
+    try:
+        return _read_spec_define(spec_lines, "el_version", r"\d+")
+    except ValueError:
+        return None
 
 
 FIPS_PROTECTED_DIRECTORIES = [

--- a/tests/kt/ktlib/test_ciq_helpers.py
+++ b/tests/kt/ktlib/test_ciq_helpers.py
@@ -1,4 +1,4 @@
-from kt.ktlib.ciq_helpers import CIQ_cherry_pick_commit_standardization
+from kt.ktlib.ciq_helpers import CIQ_cherry_pick_commit_standardization, read_spec_el_version
 
 UPSTREAM_SHA = "1234567890abcdef1234567890abcdef12345678"
 AUTHOR_TAG = "commit-author Upstream Author <author@example.com>"
@@ -29,3 +29,42 @@ def test_cherry_pick_standardization_stops_indenting_at_marker():
     lines = standardized_cherry_pick_msg()
     assert lines[-2] == f"(cherry picked from commit {UPSTREAM_SHA})\n"
     assert lines[-1] == "Signed-off-by: Backporter <backporter@example.com>\n"
+
+
+# --- read_spec_el_version tests ---
+
+
+def test_read_spec_el_version_returns_version():
+    spec_lines = [
+        "%define el_version 9\n",
+        "Name: kernel\n",
+    ]
+    assert read_spec_el_version(spec_lines) == "9"
+
+
+def test_read_spec_el_version_returns_two_digit_version():
+    spec_lines = [
+        "%define el_version 10\n",
+        "Name: kernel\n",
+    ]
+    assert read_spec_el_version(spec_lines) == "10"
+
+
+def test_read_spec_el_version_returns_none_when_missing():
+    spec_lines = [
+        "Name: kernel\n",
+        "%define kversion 6\n",
+    ]
+    assert read_spec_el_version(spec_lines) is None
+
+
+def test_read_spec_el_version_returns_none_for_non_numeric():
+    spec_lines = [
+        "%define el_version abc\n",
+        "Name: kernel\n",
+    ]
+    assert read_spec_el_version(spec_lines) is None
+
+
+def test_read_spec_el_version_empty_spec():
+    assert read_spec_el_version([]) is None

--- a/update_lt_spec.py
+++ b/update_lt_spec.py
@@ -112,15 +112,9 @@ def update_spec_file(
     """
     spec = _read_spec_file(spec_path)
 
-    # Extract el_version from spec file
-    try:
-        el_version = read_spec_el_version(spec)
-    except ValueError as e:
-        print(f"ERROR: {e}")
-        sys.exit(1)
-
-    # Construct dist string from el_version for changelog
-    dist = f".el{el_version}"
+    # Construct dist string from el_version for changelog (omit if not defined)
+    el_version = read_spec_el_version(spec)
+    dist = f".el{el_version}" if el_version else ""
 
     # Get git user info, checking both repo-level and global config
     try:
@@ -210,14 +204,9 @@ def bump_spec_file(
 
     spec = _read_spec_file(spec_path)
 
-    # Extract el_version from spec file
-    try:
-        el_version = read_spec_el_version(spec)
-    except ValueError as e:
-        print(f"ERROR: {e}")
-        sys.exit(1)
-
-    dist = f".el{el_version}"
+    # Construct dist string from el_version for changelog (omit if not defined)
+    el_version = read_spec_el_version(spec)
+    dist = f".el{el_version}" if el_version else ""
 
     # Get git user info
     try:


### PR DESCRIPTION
The 6.18 spec has been updated to work with Rocky 9 or 10 and therefore does not have a hardcoded el_version anymore.  Since the spec can be used to build for 9 or 10 it doesn't make sense to encode elX in the changelog at all.  So if a spec defines el_version we can still add it (ie. ciq-6.12.y today), but if el_version isn't defined, just leave elX out of the changelog completely.
<!-- coverage-report -->
## Coverage Report

| Name                          |    Stmts |     Miss |   Branch |   BrPart |   Cover |   Missing |
|------------------------------ | -------: | -------: | -------: | -------: | ------: | --------: |
| check\_fips\_changes.py       |       42 |       42 |       12 |        0 |      0% |      8-67 |
| check\_kernel\_commits.py     |      179 |      179 |       76 |        0 |      0% |     3-371 |
| ciq-cherry-pick.py            |      194 |      194 |       54 |        0 |      0% |     1-434 |
| ciq-tag.py                    |      146 |      146 |       16 |        0 |      0% |     3-378 |
| ciq\_tag.py                   |      232 |      232 |       54 |        0 |      0% |     1-464 |
| jira\_pr\_check.py            |      180 |      180 |       80 |        0 |      0% |     3-381 |
| kt/ktlib/ciq\_helpers.py      |      328 |      262 |      152 |        4 |     17% |31-51, 74-106, 124, 126-\>129, 129-\>136, 136-\>151, 162-172, 179-183, 187, 191-199, 208-209, 213, 217, 225-229, 240-255, 263-266, 277-314, 327-333, 346-347, 351-353, 359, 363-369, 380-382, 390-395, 404-406, 415-420, 431-444, 455-479, 489-503, 561-627, 636-646, 650-659, 669-684, 696-713 |
| kt/ktlib/command\_runner.py   |       33 |       20 |        6 |        0 |     33% |16, 20-33, 37-61, 65-66 |
| kt/ktlib/config.py            |       59 |        0 |       16 |        0 |    100% |           |
| kt/ktlib/kernel\_workspace.py |      147 |       50 |       28 |        2 |     62% |24, 100, 141-143, 148-150, 153-159, 172-183, 194-204, 221-224, 228-263 |
| kt/ktlib/kernels.py           |       96 |       13 |       20 |        1 |     86% |77-85, 139, 155-162 |
| kt/ktlib/local.py             |        5 |        1 |        0 |        0 |     80% |        12 |
| kt/ktlib/repo.py              |       29 |       15 |        2 |        0 |     45% |30-31, 34-35, 43-55 |
| kt/ktlib/ssh.py               |       12 |        5 |        2 |        0 |     50% |  9-12, 16 |
| kt/ktlib/util.py              |       17 |        0 |        0 |        0 |    100% |           |
| kt/ktlib/virt.py              |       80 |       39 |       10 |        0 |     46% |26, 34-37, 51-78, 82-88, 92-93, 97, 101, 105, 109, 119-127, 133-138, 142-147 |
| kt/ktlib/vm.py                |      302 |      152 |       52 |        4 |     47% |127-144, 177-186, 194-205, 234-238, 253-\>264, 281-\>287, 292-302, 305-306, 319-323, 326, 329-345, 350-367, 370-377, 386-392, 400-405, 426-437, 440-441, 444, 448-453, 465-478, 491-498, 507, 516-528, 531-538, 541-550, 553 |
| release\_config.py            |        2 |        2 |        0 |        0 |      0% |      7-27 |
| rolling-release-update.py     |      264 |      264 |      106 |        0 |      0% |     1-412 |
| run\_interdiff.py             |      165 |      165 |       56 |        0 |      0% |     3-244 |
| update\_lt\_spec.py           |      211 |      211 |       46 |        0 |      0% |     9-400 |
| **TOTAL**                     | **2723** | **2172** |  **788** |   **11** | **18%** |           |
