### PR TITLE
[KT VM] Make vm boot and check more resilient

### DIFF
--- a/kt/ktlib/vm.py
+++ b/kt/ktlib/vm.py
@@ -393,6 +393,12 @@ class VmInstance:
 
     def _wait_for_ssh(self):
         for attempt in range(Constants.VM_POLL_MAX_ATTEMPTS):
+            if not VirtHelper.is_running(vm_name=self.name):
+                try:
+                    VmCommand.start(vm_name=self.name)
+                except RuntimeError as e:
+                    logging.warning(f"Failed to start VM {self.name}: {e}")
+                    pass
             try:
                 SshCommand.run(domain=self.domain, command=["true"], ssh_key=self.ssh_key)
                 logging.info(f"SSH connection to {self.domain} established")
@@ -418,6 +424,11 @@ class VmInstance:
         except RuntimeError as e:
             if "closed by remote host" in str(e):
                 logging.info("VM rebooted during cloud-init, waiting for it to come back...")
+                time.sleep(Constants.VM_REBOOT_WAIT_SECONDS)
+                if not VirtHelper.is_running(vm_name=self.name):
+                    logging.info(f"VM {self.name} is not running, starting it...")
+                    VmCommand.start(vm_name=self.name)
+                    time.sleep(Constants.VM_STARTUP_WAIT_SECONDS)
                 self._wait_for_ssh()
             else:
                 raise

--- a/tests/kt/ktlib/test_vm.py
+++ b/tests/kt/ktlib/test_vm.py
@@ -252,10 +252,12 @@ def test_wait_for_cloud_init_success(mock_ssh_run):
     )
 
 
+@patch("kt.ktlib.vm.VmCommand.start")
+@patch("kt.ktlib.vm.VirtHelper.is_running", return_value=True)
 @patch("kt.ktlib.vm.time.sleep")
 @patch("kt.ktlib.vm.SshCommand.run")
-def test_wait_for_cloud_init_reboot_recovery(mock_ssh_run, mock_sleep):
-    """cloud-init reboots the VM, then SSH comes back."""
+def test_wait_for_cloud_init_reboot_recovery(mock_ssh_run, mock_sleep, mock_is_running, mock_start):
+    """cloud-init reboots the VM, VM comes back on its own, SSH comes back."""
     mock_ssh_run.side_effect = [
         RuntimeError("Connection to 192.168.122.10 closed by remote host."),
         None,  # _wait_for_ssh -> "true" succeeds
@@ -274,6 +276,29 @@ def test_wait_for_cloud_init_reboot_recovery(mock_ssh_run, mock_sleep):
         command=["true"],
         ssh_key="/tmp/fake_key",
     )
+    # VM was running after reboot, so start() should not be called
+    mock_start.assert_not_called()
+
+
+@patch("kt.ktlib.vm.VmCommand.start")
+@patch("kt.ktlib.vm.VirtHelper.is_running", side_effect=[False, True])
+@patch("kt.ktlib.vm.time.sleep")
+@patch("kt.ktlib.vm.SshCommand.run")
+def test_wait_for_cloud_init_reboot_vm_shut_off(mock_ssh_run, mock_sleep, mock_is_running, mock_start):
+    """cloud-init reboots, VM ends up shut off — start() called before waiting for SSH."""
+    mock_ssh_run.side_effect = [
+        RuntimeError("Connection to 192.168.122.10 closed by remote host."),  # cloud-init --wait
+        None,  # _wait_for_ssh -> "true" succeeds
+    ]
+    inst = _make_vm_instance()
+    inst.wait_for_cloud_init()
+
+    # VM was not running after reboot, so start() should have been called once
+    # (second is_running check in _wait_for_ssh returns True, so no second start)
+    mock_start.assert_called_once_with(vm_name="lts-9.2")
+    # REBOOT_WAIT sleep + STARTUP_WAIT sleep (from start path)
+    mock_sleep.assert_any_call(Constants.VM_REBOOT_WAIT_SECONDS)
+    mock_sleep.assert_any_call(Constants.VM_STARTUP_WAIT_SECONDS)
 
 
 @patch("kt.ktlib.vm.SshCommand.run")
@@ -284,3 +309,76 @@ def test_wait_for_cloud_init_other_error_raises(mock_ssh_run):
 
     with pytest.raises(RuntimeError, match="Permission denied"):
         inst.wait_for_cloud_init()
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_ssh — VM-start logic added in the fix
+# ---------------------------------------------------------------------------
+
+
+@patch("kt.ktlib.vm.VmCommand.start")
+@patch("kt.ktlib.vm.VirtHelper.is_running", return_value=False)
+@patch("kt.ktlib.vm.time.sleep")
+@patch("kt.ktlib.vm.SshCommand.run")
+def test_wait_for_ssh_starts_shut_off_vm(mock_ssh_run, mock_sleep, mock_is_running, mock_start):
+    """_wait_for_ssh calls VmCommand.start when VM is not running, then SSH succeeds."""
+    mock_ssh_run.return_value = ""  # SSH succeeds on first attempt
+    inst = _make_vm_instance()
+    inst._wait_for_ssh()
+
+    mock_is_running.assert_called_once_with(vm_name="lts-9.2")
+    mock_start.assert_called_once_with(vm_name="lts-9.2")
+    mock_ssh_run.assert_called_once_with(
+        domain="testuser@192.168.122.10",
+        command=["true"],
+        ssh_key="/tmp/fake_key",
+    )
+
+
+@patch("kt.ktlib.vm.VmCommand.start")
+@patch("kt.ktlib.vm.VirtHelper.is_running", return_value=True)
+@patch("kt.ktlib.vm.time.sleep")
+@patch("kt.ktlib.vm.SshCommand.run")
+def test_wait_for_ssh_skips_start_when_vm_running(mock_ssh_run, mock_sleep, mock_is_running, mock_start):
+    """_wait_for_ssh does not call VmCommand.start when VM is already running."""
+    mock_ssh_run.return_value = ""  # SSH succeeds on first attempt
+    inst = _make_vm_instance()
+    inst._wait_for_ssh()
+
+    mock_is_running.assert_called_once_with(vm_name="lts-9.2")
+    mock_start.assert_not_called()
+
+
+@patch("kt.ktlib.vm.VmCommand.start", side_effect=RuntimeError("Domain is already active"))
+@patch("kt.ktlib.vm.VirtHelper.is_running", side_effect=[False, True])
+@patch("kt.ktlib.vm.time.sleep")
+@patch("kt.ktlib.vm.SshCommand.run", side_effect=[RuntimeError("conn refused"), ""])
+def test_wait_for_ssh_start_race_then_retry(mock_ssh_run, mock_sleep, mock_is_running, mock_start):
+    """_wait_for_ssh swallows RuntimeError from VmCommand.start (race), retries SSH."""
+    inst = _make_vm_instance()
+    inst._wait_for_ssh()
+
+    # start() was called once on first iteration and raised, but exception was swallowed
+    mock_start.assert_called_once_with(vm_name="lts-9.2")
+    # SSH was tried twice: first failed, second succeeded
+    assert mock_ssh_run.call_count == 2
+    # sleep called once (between the failed SSH attempt and the retry)
+    mock_sleep.assert_called_once_with(Constants.VM_POLL_INTERVAL_SECONDS)
+
+
+@patch("kt.ktlib.vm.VmCommand.start")
+@patch("kt.ktlib.vm.VirtHelper.is_running", return_value=False)
+@patch("kt.ktlib.vm.time.sleep")
+@patch("kt.ktlib.vm.SshCommand.run", side_effect=RuntimeError("conn refused"))
+def test_wait_for_ssh_exhausts_attempts(mock_ssh_run, mock_sleep, mock_is_running, mock_start):
+    """_wait_for_ssh raises RuntimeError after exhausting all poll attempts."""
+    inst = _make_vm_instance()
+
+    with pytest.raises(RuntimeError, match="SSH to testuser@192.168.122.10 not available after 300s"):
+        inst._wait_for_ssh()
+
+    # Every attempt checked is_running + tried to start + tried SSH
+    assert mock_is_running.call_count == Constants.VM_POLL_MAX_ATTEMPTS
+    assert mock_start.call_count == Constants.VM_POLL_MAX_ATTEMPTS
+    assert mock_ssh_run.call_count == Constants.VM_POLL_MAX_ATTEMPTS
+    assert mock_sleep.call_count == Constants.VM_POLL_MAX_ATTEMPTS


### PR DESCRIPTION
During Content Release lts-9.2 the VM process was more flakey about its state than during the vm testing for previous updates.  This adds a little more failure or state oddities so that it responds better.
<!-- coverage-report -->
## Coverage Report

| Name                          |    Stmts |     Miss |   Branch |   BrPart |   Cover |   Missing |
|------------------------------ | -------: | -------: | -------: | -------: | ------: | --------: |
| check\_fips\_changes.py       |       42 |       42 |       12 |        0 |      0% |      8-67 |
| check\_kernel\_commits.py     |      179 |      179 |       76 |        0 |      0% |     3-371 |
| ciq-cherry-pick.py            |      194 |      194 |       54 |        0 |      0% |     1-434 |
| ciq-tag.py                    |      146 |      146 |       16 |        0 |      0% |     3-378 |
| ciq\_tag.py                   |      232 |      232 |       54 |        0 |      0% |     1-464 |
| jira\_pr\_check.py            |      180 |      180 |       80 |        0 |      0% |     3-381 |
| kt/ktlib/ciq\_helpers.py      |      325 |      269 |      152 |        4 |     14% |31-51, 74-106, 124, 126-\>129, 129-\>136, 136-\>151, 162-172, 179-183, 187, 191-199, 208-209, 213, 217, 225-229, 240-255, 263-266, 277-314, 327-333, 346-347, 351-353, 359, 363-369, 380-382, 390-395, 404-406, 415-420, 431-444, 455-479, 489-503, 513-518, 527, 557-623, 632-642, 646-655, 665-680, 692-709 |
| kt/ktlib/command\_runner.py   |       33 |       20 |        6 |        0 |     33% |16, 20-33, 37-61, 65-66 |
| kt/ktlib/config.py            |       59 |        0 |       16 |        0 |    100% |           |
| kt/ktlib/kernel\_workspace.py |      147 |       50 |       28 |        2 |     62% |24, 100, 141-143, 148-150, 153-159, 172-183, 194-204, 221-224, 228-263 |
| kt/ktlib/kernels.py           |       96 |       13 |       20 |        1 |     86% |77-85, 139, 155-162 |
| kt/ktlib/local.py             |        5 |        1 |        0 |        0 |     80% |        12 |
| kt/ktlib/repo.py              |       29 |       15 |        2 |        0 |     45% |30-31, 34-35, 43-55 |
| kt/ktlib/ssh.py               |       12 |        5 |        2 |        0 |     50% |  9-12, 16 |
| kt/ktlib/util.py              |       17 |        0 |        0 |        0 |    100% |           |
| kt/ktlib/virt.py              |       80 |       39 |       10 |        0 |     46% |26, 34-37, 51-78, 82-88, 92-93, 97, 101, 105, 109, 119-127, 133-138, 142-147 |
| kt/ktlib/vm.py                |      313 |      148 |       56 |        3 |     51% |127-144, 177-186, 194-205, 234-238, 253-\>264, 281-\>287, 292-302, 305-306, 319-323, 326, 329-345, 350-367, 370-377, 386-392, 437-448, 451-452, 455, 459-464, 476-489, 502-509, 518, 527-539, 542-549, 552-561, 564 |
| release\_config.py            |        2 |        2 |        0 |        0 |      0% |      7-27 |
| rolling-release-update.py     |      264 |      264 |      106 |        0 |      0% |     1-412 |
| run\_interdiff.py             |      165 |      165 |       56 |        0 |      0% |     3-244 |
| update\_lt\_spec.py           |      219 |      219 |       46 |        0 |      0% |     9-411 |
| **TOTAL**                     | **2739** | **2183** |  **792** |   **10** | **18%** |           |
